### PR TITLE
Python module was calling system.exit instead of returning exit status to the caller

### DIFF
--- a/python/arcaflow/arcaflow.py
+++ b/python/arcaflow/arcaflow.py
@@ -1,7 +1,7 @@
 import os, sys, subprocess, platform
 from .engineargs import EngineArgs
 
-def run(arg: EngineArgs):
+def run(arg: EngineArgs) -> int:
     args = []
     if arg.config != None:
         if os.path.isfile(arg.config):
@@ -32,8 +32,8 @@ def run(arg: EngineArgs):
     binary_name="arcaflow"
     if is_windows:
         binary_name="arcaflow.exe"
-    sys.exit(subprocess.call([
+    return subprocess.call([
         os.path.join(os.path.dirname(__file__), "bin",binary_name),
         *args
-    ]))
+    ])
 


### PR DESCRIPTION
## Changes introduced with this PR

The python module must return the exit status to the caller that can exit or call the engine multiple times after the first execution.
---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).