### PR TITLE
Multiple outputs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	go.flow.arcalot.io/dockerdeployer v0.2.0
 	go.flow.arcalot.io/expressions v0.1.0
 	go.flow.arcalot.io/kubernetesdeployer v0.1.0
-	go.flow.arcalot.io/pluginsdk v0.1.2
+	go.flow.arcalot.io/pluginsdk v0.1.3
 	go.flow.arcalot.io/podmandeployer v0.2.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,10 @@ go.flow.arcalot.io/pluginsdk v0.1.1 h1:dFyjaNEW/tuosHpYCb9BJLWIm5ohvXmtv6GqJn8ye
 go.flow.arcalot.io/pluginsdk v0.1.1/go.mod h1:ceY4HhUbnhZyQa3C7lXu25TNVCbsWGuYZapsV5RuIrk=
 go.flow.arcalot.io/pluginsdk v0.1.2 h1:zYtSlQCdHZ2fMF24ueboZpHp28k6TONOIhh1GJ49CGk=
 go.flow.arcalot.io/pluginsdk v0.1.2/go.mod h1:ceY4HhUbnhZyQa3C7lXu25TNVCbsWGuYZapsV5RuIrk=
+go.flow.arcalot.io/pluginsdk v0.1.3-0.20230411100529-7d8090018e15 h1:DR2p/IKcppwDrDoZC8/EyN+GfQSYN+EVBO9AE/16Fjg=
+go.flow.arcalot.io/pluginsdk v0.1.3-0.20230411100529-7d8090018e15/go.mod h1:ceY4HhUbnhZyQa3C7lXu25TNVCbsWGuYZapsV5RuIrk=
+go.flow.arcalot.io/pluginsdk v0.1.3 h1:o6v1YJmirRNcflh9ZQr5bMuhBavk8CzARjrNodU/XHA=
+go.flow.arcalot.io/pluginsdk v0.1.3/go.mod h1:ceY4HhUbnhZyQa3C7lXu25TNVCbsWGuYZapsV5RuIrk=
 go.flow.arcalot.io/podmandeployer v0.2.1 h1:TTm1+DB7L1JFNnSP55N9/FKdHmC0UFZMHupLdfLX2xI=
 go.flow.arcalot.io/podmandeployer v0.2.1/go.mod h1:EJtBVsGvI5NK/645qUMvEz8WfhDVMjH4cikYj+eE/Dk=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=

--- a/internal/infer/infer.go
+++ b/internal/infer/infer.go
@@ -1,0 +1,247 @@
+// Package infer provides the ability to construct a schema inferred from existing data and possibly expressions.
+package infer
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"reflect"
+	"regexp"
+	"time"
+
+	"go.flow.arcalot.io/expressions"
+	"go.flow.arcalot.io/pluginsdk/schema"
+)
+
+// OutputSchema either uses the passed output schema or infers the schema from the data model.
+func OutputSchema(data any, outputID string, outputSchema *schema.StepOutputSchema, internalDataModel *schema.ScopeSchema, workflowContext map[string][]byte) (*schema.StepOutputSchema, error) {
+	if outputSchema == nil {
+		inferredScope, err := Scope(data, internalDataModel, workflowContext)
+		if err != nil {
+			return nil, fmt.Errorf("unable to infer output schema for %s (%w)", outputID, err)
+		}
+		return schema.NewStepOutputSchema(
+			inferredScope,
+			nil,
+			outputID == "error",
+		), nil
+	}
+	return outputSchema, nil
+}
+
+// Scope will infer a scope from the data.
+func Scope(data any, internalDataModel *schema.ScopeSchema, workflowContext map[string][]byte) (schema.Scope, error) {
+	dataType, err := Type(data, internalDataModel, workflowContext)
+	if err != nil {
+		return nil, fmt.Errorf("failed to infer data type (%w)", err)
+	}
+	switch dataType.TypeID() {
+	case schema.TypeIDScope:
+		return dataType.(schema.Scope), nil
+	case schema.TypeIDObject:
+		return schema.NewScopeSchema(
+			dataType.(*schema.ObjectSchema),
+		), nil
+	default:
+		return nil, fmt.Errorf(
+			"invalid type for output root object: %s (must be an object)",
+			dataType.TypeID(),
+		)
+	}
+}
+
+// Type attempts to infer the data model from the data, possibly evaluating expressions.
+func Type(data any, internalDataModel *schema.ScopeSchema, workflowContext map[string][]byte) (schema.Type, error) {
+	if expression, ok := data.(expressions.Expression); ok {
+		expressionType, err := expression.Type(internalDataModel, workflowContext)
+		if err != nil {
+			return nil, fmt.Errorf("failed to evaluate type of expression %s (%w)", expression.String(), err)
+		}
+		return expressionType, nil
+	}
+	v := reflect.ValueOf(data)
+	switch v.Kind() {
+	case reflect.Map:
+		return mapType(v, internalDataModel, workflowContext)
+	case reflect.Slice:
+		return sliceType(v, internalDataModel, workflowContext)
+	case reflect.String:
+		return schema.NewStringSchema(nil, nil, nil), nil
+	case reflect.Int8:
+		return schema.NewIntSchema(schema.PointerTo[int64](math.MinInt8), schema.PointerTo[int64](math.MaxInt8), nil), nil
+	case reflect.Int16:
+		return schema.NewIntSchema(schema.PointerTo[int64](math.MinInt16), schema.PointerTo[int64](math.MaxInt16), nil), nil
+	case reflect.Int32:
+		return schema.NewIntSchema(schema.PointerTo[int64](math.MinInt32), schema.PointerTo[int64](math.MaxInt32), nil), nil
+	case reflect.Int64:
+		return schema.NewIntSchema(schema.PointerTo[int64](math.MinInt64), schema.PointerTo[int64](math.MaxInt64), nil), nil
+	case reflect.Int:
+		return schema.NewIntSchema(schema.PointerTo[int64](math.MinInt), schema.PointerTo[int64](math.MaxInt), nil), nil
+	case reflect.Uint8:
+		return schema.NewIntSchema(schema.PointerTo[int64](0), schema.PointerTo[int64](math.MaxUint8), nil), nil
+	case reflect.Uint16:
+		return schema.NewIntSchema(schema.PointerTo[int64](0), schema.PointerTo[int64](math.MaxUint16), nil), nil
+	case reflect.Uint32:
+		return schema.NewIntSchema(schema.PointerTo[int64](0), schema.PointerTo[int64](math.MaxUint32), nil), nil
+	case reflect.Uint64:
+		return schema.NewIntSchema(
+			schema.PointerTo[int64](0),
+			// The MaxInt64 is not a mistake here, uints have a larger range than the Arca-standard 64-bit ints.
+			schema.PointerTo[int64](math.MaxInt64),
+			nil), nil
+	case reflect.Uint:
+		return schema.NewIntSchema(
+			schema.PointerTo[int64](0),
+			// The MaxInt is not a mistake here, uints have a larger range than the Arca-standard 64-bit ints.
+			schema.PointerTo[int64](math.MaxInt),
+			nil,
+		), nil
+	case reflect.Float64:
+		return schema.NewFloatSchema(nil, nil, nil), nil
+	case reflect.Float32:
+		return schema.NewFloatSchema(nil, nil, nil), nil
+	case reflect.Bool:
+		return schema.NewBoolSchema(), nil
+	case reflect.Ptr:
+		if _, ok := data.(*regexp.Regexp); ok {
+			return schema.NewPatternSchema(), nil
+		}
+		fallthrough
+	default:
+		return nil, fmt.Errorf("unsupported type for workflow outputs: %T", data)
+	}
+}
+
+// mapType infers the type of a map value.
+func mapType(
+	v reflect.Value,
+	internalDataModel *schema.ScopeSchema,
+	workflowContext map[string][]byte,
+) (schema.Type, error) {
+	keyType, err := sliceItemType(v.MapKeys(), internalDataModel, workflowContext)
+	if err != nil {
+		return nil, fmt.Errorf("failed to infer map key type (%w)", err)
+	}
+	switch keyType.TypeID() {
+	case schema.TypeIDString:
+		fallthrough
+	case schema.TypeIDStringEnum:
+		return objectType(v, internalDataModel, workflowContext)
+	case schema.TypeIDInt:
+	case schema.TypeIDIntEnum:
+	default:
+		return nil, fmt.Errorf("unsupported type for map keys: %s", keyType.TypeID())
+	}
+	var foundType schema.Type
+	for _, mapKey := range v.MapKeys() {
+		mapValue := v.MapIndex(mapKey)
+		mapValueAny := mapValue.Interface()
+		valueType, err := Type(mapValueAny, internalDataModel, workflowContext)
+		if err != nil {
+			return nil, fmt.Errorf("failed to infer type of %d (%w)", mapValueAny, err)
+		}
+		if foundType == nil {
+			foundType = valueType
+		} else if foundType.TypeID() != valueType.TypeID() {
+			return nil, fmt.Errorf(
+				"type mismatch in map type (expected: %s, found: %s)",
+				foundType.TypeID(),
+				valueType.TypeID(),
+			)
+		}
+	}
+	if foundType == nil {
+		return schema.NewMapSchema(
+			keyType,
+			schema.NewStringSchema(nil, schema.PointerTo[int64](0), nil),
+			nil,
+			schema.PointerTo[int64](0),
+		), nil
+	}
+	return schema.NewMapSchema(
+		keyType,
+		foundType,
+		nil,
+		nil,
+	), nil
+}
+
+func objectType(
+	value reflect.Value,
+	internalDataModel *schema.ScopeSchema,
+	workflowContext map[string][]byte,
+) (schema.Type, error) {
+	properties := make(map[string]*schema.PropertySchema, value.Len())
+	for _, keyValue := range value.MapKeys() {
+		propertyType, err := Type(value.MapIndex(keyValue).Interface(), internalDataModel, workflowContext)
+		if err != nil {
+			return nil, fmt.Errorf("failed to infer property %s type (%w)", keyValue.Interface(), err)
+		}
+		properties[keyValue.Interface().(string)] = schema.NewPropertySchema(
+			propertyType,
+			nil,
+			true,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+	}
+	return schema.NewObjectSchema(
+		generateRandomObjectID(),
+		properties,
+	), nil
+}
+
+// sliceType tries to infer the type of a slice.
+func sliceType(
+	v reflect.Value,
+	internalDataModel *schema.ScopeSchema,
+	workflowContext map[string][]byte,
+) (schema.Type, error) {
+	values := make([]reflect.Value, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		values[i] = v.Index(i)
+	}
+	foundType, err := sliceItemType(values, internalDataModel, workflowContext)
+	if err != nil {
+		return nil, err
+	}
+	return schema.NewListSchema(
+		foundType,
+		nil,
+		nil,
+	), nil
+}
+
+func sliceItemType(values []reflect.Value, internalDataModel *schema.ScopeSchema, workflowContext map[string][]byte) (schema.Type, error) {
+	types := make([]schema.Type, len(values))
+	var foundType schema.Type
+	for i, value := range values {
+		var err error
+		types[i], err = Type(value.Interface(), internalDataModel, workflowContext)
+		if err != nil {
+			return nil, fmt.Errorf("failed to infer type for item %d (%w)", i, err)
+		}
+		if foundType == nil {
+			foundType = types[i]
+		} else if foundType.TypeID() != types[i].TypeID() {
+			return nil, fmt.Errorf("mismatching types in list (expected: %s, found: %s)", foundType.TypeID(), types[i].TypeID())
+		}
+	}
+	if foundType == nil {
+		return schema.NewStringSchema(nil, nil, nil), nil
+	}
+	return foundType, nil
+}
+
+var characters = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+var objectIDRandom = rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
+func generateRandomObjectID() string {
+	result := make([]rune, 32)
+	for i := range result {
+		result[i] = characters[objectIDRandom.Intn(len(characters))]
+	}
+	return string(result)
+}

--- a/internal/infer/infer_test.go
+++ b/internal/infer/infer_test.go
@@ -1,0 +1,73 @@
+package infer_test
+
+import (
+	"fmt"
+	"testing"
+
+	"go.flow.arcalot.io/engine/internal/infer"
+	"go.flow.arcalot.io/pluginsdk/schema"
+)
+
+type testEntry struct {
+	name               string
+	input              any
+	expectedOutputType schema.TypeID
+	validate           func(t schema.Type) error
+}
+
+var testData = []testEntry{
+	{
+		"string",
+		"foo",
+		schema.TypeIDString,
+		func(t schema.Type) error {
+			return nil
+		},
+	},
+	{
+		"object",
+		map[string]any{
+			"foo": "bar",
+			"baz": 42,
+		},
+		schema.TypeIDObject,
+		func(t schema.Type) error {
+			objectSchema := t.(*schema.ObjectSchema)
+			properties := objectSchema.Properties()
+			if properties["foo"].TypeID() != schema.TypeIDString {
+				return fmt.Errorf("incorrect property type for 'foo': %s", properties["foo"].TypeID())
+			}
+			if properties["baz"].TypeID() != schema.TypeIDInt {
+				return fmt.Errorf("incorrect property type for 'foo': %s", properties["foo"].TypeID())
+			}
+			return nil
+		},
+	},
+	{
+		"slice",
+		[]string{"foo"},
+		schema.TypeIDList,
+		func(t schema.Type) error {
+			listType := t.(*schema.ListSchema)
+			if listType.Items().TypeID() != schema.TypeIDString {
+				return fmt.Errorf("incorrect property type list item: %s", listType.Items().TypeID())
+			}
+			return nil
+		},
+	},
+}
+
+func TestInfer(t *testing.T) {
+	for _, entry := range testData {
+		t.Run(entry.name, func(t *testing.T) {
+			inferredType, err := infer.Type(entry.input, nil, nil)
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
+			if inferredType.TypeID() != entry.expectedOutputType {
+				t.Fatalf("Incorrect type inferred: %s", inferredType.TypeID())
+			}
+		})
+	}
+
+}

--- a/internal/step/dummy/provider.go
+++ b/internal/step/dummy/provider.go
@@ -143,6 +143,30 @@ func (r *runnableStep) Lifecycle(_ map[string]any) (result step.Lifecycle[step.L
 						),
 						ErrorValue: false,
 					},
+					"error": {
+						SchemaValue: schema.NewScopeSchema(
+							schema.NewObjectSchema(
+								"error",
+								map[string]*schema.PropertySchema{
+									"reason": schema.NewPropertySchema(
+										schema.NewStringSchema(nil, nil, nil),
+										schema.NewDisplayValue(
+											schema.PointerTo("Message"),
+											nil,
+											nil,
+										),
+										true,
+										nil,
+										nil,
+										nil,
+										nil,
+										nil,
+									),
+								},
+							),
+						),
+						ErrorValue: true,
+					},
 				},
 			},
 		},

--- a/workflow/executor_example_test.go
+++ b/workflow/executor_example_test.go
@@ -26,8 +26,9 @@ steps:
   say_hi:
     kind: dummy
     name: !expr $.input.name
-output:
-  message: !expr $.steps.say_hi.greet.success.message
+outputs:
+  success:
+    message: !expr $.steps.say_hi.greet.success.message
 `
 
 func ExampleExecutor() {
@@ -54,12 +55,12 @@ func ExampleExecutor() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	outputData, err := preparedWorkflow.Execute(ctx, map[string]any{
+	outputID, outputData, err := preparedWorkflow.Execute(ctx, map[string]any{
 		"name": "Arca Lot",
 	})
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(outputData.(map[any]any)["message"])
-	// Output: Hello Arca Lot!
+	fmt.Printf("%s: %s\n", outputID, outputData.(map[any]any)["message"])
+	// Output: success: Hello Arca Lot!
 }

--- a/workflow/executor_test.go
+++ b/workflow/executor_test.go
@@ -60,12 +60,12 @@ func TestSharedInput(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	outputData, err := preparedWorkflow.Execute(ctx, map[string]any{
+	outputID, outputData, err := preparedWorkflow.Execute(ctx, map[string]any{
 		"name": "Arca Lot",
 	})
 	if err != nil {
 		t.Fatalf("Error while executing workflow, %e", err)
 	}
-	fmt.Println(outputData.(map[any]any)["message"])
-	// Output: Hello Arca Lot!
+	fmt.Printf("%s: %s\n", outputID, outputData.(map[any]any)["message"])
+	// Output: success: Hello Arca Lot!
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -4,10 +4,11 @@ package workflow
 import (
 	"context"
 	"fmt"
-	"go.flow.arcalot.io/engine/config"
 	"reflect"
 	"strings"
 	"sync"
+
+	"go.flow.arcalot.io/engine/config"
 
 	"go.arcalot.io/dgraph"
 	"go.arcalot.io/log/v2"
@@ -28,6 +29,11 @@ type executableWorkflow struct {
 	internalDataModel *schema.ScopeSchema
 	runnableSteps     map[string]step.RunnableStep
 	lifecycles        map[string]step.Lifecycle[step.LifecycleStageWithSchema]
+	outputSchema      map[string]*schema.StepOutputSchema
+}
+
+func (e *executableWorkflow) OutputSchema() map[string]*schema.StepOutputSchema {
+	return e.outputSchema
 }
 
 // Input returns a schema scope that can be used to validate the input.
@@ -42,11 +48,11 @@ func (e *executableWorkflow) DAG() dgraph.DirectedGraph[*DAGItem] {
 
 // Execute runs the workflow with the specified input. You can use the context variable to abort the workflow execution
 // (e.g. when the user presses Ctrl+C).
-func (e *executableWorkflow) Execute(ctx context.Context, input any) (outputData any, err error) {
+func (e *executableWorkflow) Execute(ctx context.Context, input any) (outputID string, outputData any, err error) { //nolint:gocognit
 	// First, we unserialize the input. This makes sure we didn't get garbage data.
 	unserializedInput, err := e.input.Unserialize(input)
 	if err != nil {
-		return nil, fmt.Errorf("invalid workflow input (%w)", err)
+		return "", nil, fmt.Errorf("invalid workflow input (%w)", err)
 	}
 
 	// We use an internal cancel function to abort the workflow if something bad happens.
@@ -64,7 +70,7 @@ func (e *executableWorkflow) Execute(ctx context.Context, input any) (outputData
 		dag:               e.dag.Clone(),
 		inputsNotified:    make(map[string]struct{}, len(e.dag.ListNodes())),
 		runningSteps:      make(map[string]step.RunningStep, len(e.dag.ListNodes())),
-		outputDataChannel: make(chan any, 1),
+		outputDataChannel: make(chan outputDataType, 1),
 		outputDone:        false,
 		cancel:            cancel,
 		workflowContext:   e.workflowContext,
@@ -105,7 +111,7 @@ func (e *executableWorkflow) Execute(ctx context.Context, input any) (outputData
 		e.logger.Debugf("Launching step %s...", stepID)
 		runningStep, err := runnableStep.Start(e.stepRunData[stepID], stageHandler)
 		if err != nil {
-			return nil, fmt.Errorf("failed to launch step %s (%w)", stepID, err)
+			return "", nil, fmt.Errorf("failed to launch step %s (%w)", stepID, err)
 		}
 		l.runningSteps[stepID] = runningStep
 	}
@@ -125,10 +131,10 @@ func (e *executableWorkflow) Execute(ctx context.Context, input any) (outputData
 	e.logger.Debugf("Starting workflow execution...\n%s", l.dag.Mermaid())
 	inputNode, err := l.dag.GetNodeByID("input")
 	if err != nil {
-		return nil, fmt.Errorf("bug: cannot obtain input node (%w)", err)
+		return "", nil, fmt.Errorf("bug: cannot obtain input node (%w)", err)
 	}
 	if err := inputNode.Remove(); err != nil {
-		return nil, fmt.Errorf("failed to remove input node from DAG (%w)", err)
+		return "", nil, fmt.Errorf("failed to remove input node from DAG (%w)", err)
 	}
 
 	func() {
@@ -141,19 +147,40 @@ func (e *executableWorkflow) Execute(ctx context.Context, input any) (outputData
 
 	// Now we wait for the workflow results.
 	select {
-	case outputData, ok := <-l.outputDataChannel:
+	case outputDataEntry, ok := <-l.outputDataChannel:
 		if !ok {
-			return nil, fmt.Errorf("output data channel unexpectedly closed")
+			return "", nil, fmt.Errorf("output data channel unexpectedly closed")
 		}
 		e.logger.Debugf("Output complete.")
-		return outputData, nil
+		outputID = outputDataEntry.outputID
+		outputData = outputDataEntry.outputData
+		outputSchema, ok := e.outputSchema[outputID]
+		if !ok {
+			return "", nil, fmt.Errorf(
+				"bug: no output named '%s' found in output schema",
+				outputID,
+			)
+		}
+		_, err := outputSchema.Unserialize(outputDataEntry.outputData)
+		if err != nil {
+			return "", nil, fmt.Errorf(
+				"bug: output schema cannot unserialize output data (%w)",
+				err,
+			)
+		}
+		return outputDataEntry.outputID, outputData, nil
 	case <-ctx.Done():
 		e.logger.Debugf("Workflow execution aborted. %s", l.lastError)
 		if l.lastError != nil {
-			return nil, l.lastError
+			return "", nil, l.lastError
 		}
-		return nil, fmt.Errorf("workflow execution aborted (%w)", ctx.Err())
+		return "", nil, fmt.Errorf("workflow execution aborted (%w)", ctx.Err())
 	}
+}
+
+type outputDataType struct {
+	outputID   string
+	outputData any
 }
 
 type loopState struct {
@@ -164,7 +191,7 @@ type loopState struct {
 	dag               dgraph.DirectedGraph[*DAGItem]
 	inputsNotified    map[string]struct{}
 	runningSteps      map[string]step.RunningStep
-	outputDataChannel chan any
+	outputDataChannel chan outputDataType
 	outputDone        bool
 	lastError         error
 	cancel            context.CancelFunc
@@ -242,7 +269,7 @@ func (l *loopState) notifySteps() { //nolint:gocognit
 			continue
 		}
 		l.inputsNotified[nodeID] = struct{}{}
-		inputData := node.Item().Input
+		inputData := node.Item().Data
 		if inputData == nil {
 			// No input data is needed.
 			continue
@@ -255,11 +282,11 @@ func (l *loopState) notifySteps() { //nolint:gocognit
 
 		switch node.Item().Kind {
 		case DAGItemKindStepStage:
-			if node.Item().InputSchema == nil {
+			if node.Item().DataSchema == nil {
 				break
 			}
 			// We have a stage we can proceed with. Let's provide it with input.
-			if _, err := node.Item().InputSchema.Unserialize(untypedInputData); err != nil {
+			if _, err := node.Item().DataSchema.Unserialize(untypedInputData); err != nil {
 				l.logger.Errorf("Bug: schema evaluation resulted in invalid data for %s (%v)", node.ID(), err)
 				l.lastError = fmt.Errorf("bug: schema evaluation resulted in invalid data for %s (%w)", node.ID(), err)
 				l.cancel()
@@ -287,7 +314,11 @@ func (l *loopState) notifySteps() { //nolint:gocognit
 			// We have received enough data to construct the workflow output.
 			l.logger.Debugf("Constructing workflow output.")
 			l.outputDone = true
-			l.outputDataChannel <- untypedInputData
+
+			l.outputDataChannel <- outputDataType{
+				outputID:   node.Item().OutputID,
+				outputData: untypedInputData,
+			}
 
 			if err := node.Remove(); err != nil {
 				l.logger.Errorf("BUG: Error occurred while removing workflow output node (%w)", err)

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -1,0 +1,63 @@
+package workflow_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.arcalot.io/assert"
+	"go.arcalot.io/lang"
+	"go.arcalot.io/log/v2"
+	"go.flow.arcalot.io/engine/config"
+	"go.flow.arcalot.io/engine/internal/step/dummy"
+	"go.flow.arcalot.io/engine/internal/step/registry"
+	"go.flow.arcalot.io/engine/workflow"
+)
+
+var workflowDefinition = `
+input:
+  root: name
+  objects:
+    name:
+      id: name
+      properties:
+        name:
+          type:
+            type_id: string
+steps:
+  say_hi:
+    kind: dummy
+    name: !expr $.input.name
+output:
+  thiswillfail: !expr $.steps.say_hi.greet.error.reason
+`
+
+func TestOutputFailed(t *testing.T) {
+	logConfig := log.Config{
+		Level:       log.LevelError,
+		Destination: log.DestinationStdout,
+	}
+	logger := log.New(
+		logConfig,
+	)
+	cfg := &config.Config{
+		Log: logConfig,
+	}
+	stepRegistry := lang.Must2(registry.New(
+		dummy.New(),
+	))
+	executor := lang.Must2(workflow.NewExecutor(
+		logger,
+		cfg,
+		stepRegistry,
+	))
+	wf := lang.Must2(workflow.NewYAMLConverter(stepRegistry).FromYAML([]byte(workflowDefinition)))
+	preparedWorkflow := lang.Must2(executor.Prepare(wf, map[string][]byte{}))
+	_, outputData, err := preparedWorkflow.Execute(context.Background(), map[string]any{"name": "Arca Lot"})
+	assert.Nil(t, outputData)
+	assert.Error(t, err)
+	var typedError *workflow.ErrNoMorePossibleSteps
+	if !errors.As(err, &typedError) {
+		t.Fatalf("incorrect error type returned: %T", err)
+	}
+}


### PR DESCRIPTION
## Changes introduced with this PR

This PR fixes #72 and adds multiple outputs to workflows, similar to steps. This PR is based on #32.

This PR changes the workflow format from having the `output` key to having an `outputs` key like this:

```yaml
outputs:
  success:
    message: !expr $...
```

You can additionally define a schema for the outputs:

```yaml
outputSchema:
  success:
    display: // Display properties here
    error: true|false
    schema: // Scope definition here
```

If no explicit output schema is defined, one will be infered from the expressions.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).