### PR TITLE
Added deployer selection to run-plugin

### DIFF
--- a/cmd/run-plugin/run.go
+++ b/cmd/run-plugin/run.go
@@ -5,12 +5,15 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"go.flow.arcalot.io/deployer"
+	podman "go.flow.arcalot.io/podmandeployer"
 	"os"
 	"os/signal"
 
 	log "go.arcalot.io/log/v2"
 	docker "go.flow.arcalot.io/dockerdeployer"
 	"go.flow.arcalot.io/pluginsdk/atp"
+	testdeployer "go.flow.arcalot.io/testdeployer"
 	"gopkg.in/yaml.v3"
 )
 
@@ -18,18 +21,49 @@ func main() {
 	var image string
 	var file string
 	var stepID string
+	var d deployer.AnyConnectorFactory
+	var defaultConfig any
+	var deployerID = "docker"
 
 	flag.StringVar(&image, "image", image, "Docker image to run")
 	flag.StringVar(&file, "file", file, "Input file")
 	flag.StringVar(&stepID, "step", stepID, "Step name")
+	flag.StringVar(&deployerID, "deployer", stepID, "The name of the deployer")
 	flag.Parse()
 
-	d := docker.NewFactory()
-	configSchema := d.ConfigurationSchema()
-	defaultConfig, err := configSchema.UnserializeType(map[string]any{})
-	if err != nil {
-		panic(err)
+	switch deployerID {
+	case "docker":
+		dockerFactory := docker.NewFactory()
+		d = deployer.Any(dockerFactory)
+
+		configSchema := dockerFactory.ConfigurationSchema()
+		var err error
+		defaultConfig, err = configSchema.UnserializeType(map[string]any{})
+		if err != nil {
+			panic(err)
+		}
+	case "podman":
+		podmanFactory := podman.NewFactory()
+		d = deployer.Any(podmanFactory)
+		configSchema := podmanFactory.ConfigurationSchema()
+		var err error
+		defaultConfig, err = configSchema.UnserializeType(map[string]any{})
+		if err != nil {
+			panic(err)
+		}
+	case "testimpl":
+		podmanFactory := testdeployer.NewFactory()
+		d = deployer.Any(podmanFactory)
+		configSchema := podmanFactory.ConfigurationSchema()
+		var err error
+		defaultConfig, err = configSchema.UnserializeType(map[string]any{})
+		if err != nil {
+			panic(err)
+		}
+	default:
+		panic("No deployer selected. Options: docker, podman, testimpl. Select with -deployer")
 	}
+
 	connector, err := d.Create(defaultConfig, log.New(log.Config{
 		Level:       log.LevelDebug,
 		Destination: log.DestinationStdout,
@@ -52,6 +86,7 @@ func main() {
 		}
 	}()
 
+	fmt.Println("Deploying")
 	plugin, err := connector.Deploy(ctx, image)
 	if err != nil {
 		panic(err)
@@ -63,6 +98,7 @@ func main() {
 	}()
 
 	atpClient := atp.NewClient(plugin)
+	fmt.Println("Getting schema")
 	pluginSchema, err := atpClient.ReadSchema()
 	if err != nil {
 		panic(err)
@@ -83,6 +119,7 @@ func main() {
 	if _, err := step.Input().Unserialize(input); err != nil {
 		panic(err)
 	}
+	fmt.Printf("Running step %s\n", stepID)
 	outputID, outputData, err := atpClient.Execute(stepID, input)
 	output := map[string]any{
 		"outputID":   outputID,

--- a/cmd/run-plugin/run.go
+++ b/cmd/run-plugin/run.go
@@ -61,7 +61,7 @@ func main() {
 			panic(err)
 		}
 	default:
-		panic("No deployer selected. Options: docker, podman, testimpl. Select with -deployer")
+		panic("No deployer or invalid deployer selected. Options: docker, podman, testimpl. Select with -deployer")
 	}
 
 	connector, err := d.Create(defaultConfig, log.New(log.Config{


### PR DESCRIPTION
## Changes introduced with this PR

I wanted to make a PR for this because I have found it useful in my testing.

The run-step feature is more of a development tool that lets you run a step using parts of the engine code without needing to run a workflow.
This just makes it so you select the deployer, with the options being between docker, podman, and the test impl (which only has its own steps and ignores your input). I didn't add the kubernetes deployer because it's useless without a config, and that's a little out of scope of this tool.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).