### PR TITLE
Fix and Update CI Regular Expression

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
         env:
           VERSION: ${{ github.ref_name }}
         run: |
-          [[  ${VERSION//[[:blank:]]/} =~ ^v[[:digit:]]+\.[[:digit:]]\.[[:digit:]]$ ]] && export OK="[INF] version format accepted" 
+          [[  ${VERSION//[[:blank:]]/} =~ ^v[[:digit:]]+\.[[:digit:]]\.[[:digit:]](-[[:alnum:]]+)?(\+[[:alnum:]]+)?$ ]] && export OK="[INF] version format accepted" 
           [[ -z $OK ]] && echo "[ERR] wrong version format: $VERSION" && exit 1
           echo $OK
       - name: Check out code


### PR DESCRIPTION
## Changes introduced with this PR

Update the version format regular expression to include potential pre-release and/or build identifiers as in the [semantic versioning 2.0.0 specification](https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions).


```
<valid semver> ::= <version core>
                 | <version core> "-" <pre-release>
                 | <version core> "+" <build>
                 | <version core> "-" <pre-release> "+" <build>

<version core> ::= <major> "." <minor> "." <patch>
```

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).