### PR TITLE
Allow waiting for starting complete

### DIFF
--- a/internal/step/plugin/provider.go
+++ b/internal/step/plugin/provider.go
@@ -321,8 +321,6 @@ func (r *runnableStep) RunSchema() map[string]*schema.PropertySchema {
 	}
 }
 
-type StartedOutput struct{}
-
 func (r *runnableStep) StartedSchema() *schema.StepOutputSchema {
 	return schema.NewStepOutputSchema(
 		schema.NewScopeSchema(
@@ -1053,8 +1051,6 @@ func (r *runningStep) transitionStage(newStage StageID, state step.RunningStepSt
 }
 
 // TransitionStage transitions the stage to the specified stage, and the state to the specified state.
-//
-//nolint:unparam
 func (r *runningStep) transitionStageWithOutput(newStage StageID, state step.RunningStepState, outputID *string, previousStageOutput *any) {
 	// A current lack of observability into the atp client prevents
 	// non-fragile testing of this function.

--- a/internal/step/plugin/provider.go
+++ b/internal/step/plugin/provider.go
@@ -321,6 +321,21 @@ func (r *runnableStep) RunSchema() map[string]*schema.PropertySchema {
 	}
 }
 
+type StartedOutput struct{}
+
+func (r *runnableStep) StartedSchema() *schema.StepOutputSchema {
+	return schema.NewStepOutputSchema(
+		schema.NewScopeSchema(
+			schema.NewObjectSchema(
+				"StartedOutput",
+				map[string]*schema.PropertySchema{},
+			),
+		),
+		nil,
+		false,
+	)
+}
+
 func (r *runnableStep) Lifecycle(input map[string]any) (result step.Lifecycle[step.LifecycleStageWithSchema], err error) {
 	rawStepID, ok := input["step"]
 	if !ok || rawStepID == nil {
@@ -446,6 +461,9 @@ func (r *runnableStep) Lifecycle(input map[string]any) (result step.Lifecycle[st
 						nil,
 						nil,
 					),
+				},
+				Outputs: map[string]*schema.StepOutputSchema{
+					"started": r.StartedSchema(),
 				},
 			},
 			{
@@ -954,7 +972,8 @@ func (r *runningStep) startStage(container deployer.Plugin) error {
 
 func (r *runningStep) runStage() error {
 	r.logger.Debugf("Running stage for step %s/%s", r.runID, r.pluginStepID)
-	r.transitionStage(StageIDRunning, step.RunningStepStateRunning)
+	startedOutput := any(map[any]any{})
+	r.transitionStageWithOutput(StageIDRunning, step.RunningStepStateRunning, schema.PointerTo("started"), &startedOutput)
 
 	var result atp.ExecutionResult
 	select {
@@ -981,7 +1000,7 @@ func (r *runningStep) runStage() error {
 
 	// Execution complete, move to state running stage outputs, then to state finished stage.
 	r.transitionStage(StageIDOutput, step.RunningStepStateRunning)
-	r.completeStage(r.currentStage, step.RunningStepStateFinished, &result.OutputID, &result.OutputData)
+	r.completeStep(r.currentStage, step.RunningStepStateFinished, &result.OutputID, &result.OutputData)
 
 	return nil
 }
@@ -996,7 +1015,7 @@ func (r *runningStep) deployFailed(err error) {
 	output := any(DeployFailed{
 		Error: err.Error(),
 	})
-	r.completeStage(StageIDDeployFailed, step.RunningStepStateFinished, &outputID, &output)
+	r.completeStep(StageIDDeployFailed, step.RunningStepStateFinished, &outputID, &output)
 }
 
 func (r *runningStep) startFailed(err error) {
@@ -1010,7 +1029,7 @@ func (r *runningStep) startFailed(err error) {
 		Output: err.Error(),
 	})
 
-	r.completeStage(StageIDCrashed, step.RunningStepStateFinished, &outputID, &output)
+	r.completeStep(StageIDCrashed, step.RunningStepStateFinished, &outputID, &output)
 }
 
 func (r *runningStep) runFailed(err error) {
@@ -1023,13 +1042,20 @@ func (r *runningStep) runFailed(err error) {
 	output := any(Crashed{
 		Output: err.Error(),
 	})
-	r.completeStage(StageIDCrashed, step.RunningStepStateFinished, &outputID, &output)
+	r.completeStep(StageIDCrashed, step.RunningStepStateFinished, &outputID, &output)
 }
 
 // TransitionStage transitions the stage to the specified stage, and the state to the specified state.
 //
 //nolint:unparam
 func (r *runningStep) transitionStage(newStage StageID, state step.RunningStepState) {
+	r.transitionStageWithOutput(newStage, state, nil, nil)
+}
+
+// TransitionStage transitions the stage to the specified stage, and the state to the specified state.
+//
+//nolint:unparam
+func (r *runningStep) transitionStageWithOutput(newStage StageID, state step.RunningStepState, outputID *string, previousStageOutput *any) {
 	// A current lack of observability into the atp client prevents
 	// non-fragile testing of this function.
 	r.lock.Lock()
@@ -1042,8 +1068,8 @@ func (r *runningStep) transitionStage(newStage StageID, state step.RunningStepSt
 	r.stageChangeHandler.OnStageChange(
 		r,
 		&previousStage,
-		nil,
-		nil,
+		outputID,
+		previousStageOutput,
 		string(newStage),
 		false,
 		&r.wg,
@@ -1051,7 +1077,7 @@ func (r *runningStep) transitionStage(newStage StageID, state step.RunningStepSt
 }
 
 //nolint:unparam
-func (r *runningStep) completeStage(currentStage StageID, state step.RunningStepState, outputID *string, previousStageOutput *any) {
+func (r *runningStep) completeStep(currentStage StageID, state step.RunningStepState, outputID *string, previousStageOutput *any) {
 	r.lock.Lock()
 	previousStage := string(r.currentStage)
 	r.currentStage = currentStage

--- a/internal/step/plugin/provider_test.go
+++ b/internal/step/plugin/provider_test.go
@@ -399,7 +399,7 @@ func TestProvider_VerifyCancelSignal(t *testing.T) {
 	waitStageIDCancelled := waitLifecycle.Stages[waitCancelledStageIDIndex]
 	waitStopIfSchema := assert.MapContainsKey(t, "stop_if", waitStageIDCancelled.InputSchema)
 	if waitStopIfSchema.Disabled {
-		t.Fatalf("step wait's wait_for schema is disabled when the cancel signal is present.")
+		t.Fatalf("step wait's stop_if schema is disabled when the cancel signal is present.")
 	}
 
 	helloLifecycle, err := runnable.Lifecycle(map[string]any{"step": "hello"})

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -463,7 +463,7 @@ func (e *executor) createTypeStructure(rootSchema schema.Scope, inputField any, 
 			value := v.Index(i).Interface()
 			newValue, err := e.createTypeStructure(rootSchema, value, workflowContext)
 			if err != nil {
-				return nil, fmt.Errorf("failed to resolve expressions (%w)", err)
+				return nil, fmt.Errorf("failed to resolve slice expressions (%w)", err)
 			}
 			result[i] = newValue
 		}
@@ -479,7 +479,7 @@ func (e *executor) createTypeStructure(rootSchema schema.Scope, inputField any, 
 			value := v.MapIndex(reflectedKey).Interface()
 			newValue, err := e.createTypeStructure(rootSchema, value, workflowContext)
 			if err != nil {
-				return nil, fmt.Errorf("failed to resolve expressions (%w)", err)
+				return nil, fmt.Errorf("failed to resolve map expressions (%w)", err)
 			}
 			result[keyAsStr] = newValue
 		}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -524,7 +524,7 @@ func (l *loopState) resolveExpressions(inputData any, dataModel any) (any, error
 			value := v.Index(i).Interface()
 			newValue, err := l.resolveExpressions(value, dataModel)
 			if err != nil {
-				return nil, fmt.Errorf("failed to resolve expressions (%w)", err)
+				return nil, fmt.Errorf("failed to resolve workflow slice expressions (%w)", err)
 			}
 			result[i] = newValue
 		}
@@ -536,7 +536,7 @@ func (l *loopState) resolveExpressions(inputData any, dataModel any) (any, error
 			value := v.MapIndex(reflectedKey).Interface()
 			newValue, err := l.resolveExpressions(value, dataModel)
 			if err != nil {
-				return nil, fmt.Errorf("failed to resolve expressions (%w)", err)
+				return nil, fmt.Errorf("failed to resolve workflow map expressions (%w)", err)
 			}
 			result[key] = newValue
 		}


### PR DESCRIPTION
I set this to a draft because I'd like feedback before merging.

This is possible by creating an output for starting.

I'm open to suggestions for the naming of the output. Technically speaking started is completed just before instructing the ATP server to start the step. So technically it's not started. But practically speaking, it is.

I have it set to `started`, which results in the node `$.steps.nameofstep.starting.started`.
Other possible output names include "complete", "done", and "finished", resulting in something like `$.steps.nameofstep.starting.complete`

I'm also open to feedback on if you want to pursue an alternative way of enabling this functionality.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).