### PR TITLE
Initial floatToFormattedString() implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,13 @@ go 1.21
 toolchain go1.21.6
 
 require (
-	go.arcalot.io/assert v1.7.0
+	go.arcalot.io/assert v1.8.0
 	go.arcalot.io/dgraph v1.2.0
 	go.arcalot.io/lang v1.1.0
 	go.arcalot.io/log/v2 v2.1.0
 	go.flow.arcalot.io/deployer v0.5.0
 	go.flow.arcalot.io/dockerdeployer v0.6.1
-	go.flow.arcalot.io/expressions v0.4.0
+	go.flow.arcalot.io/expressions v0.4.1
 	go.flow.arcalot.io/kubernetesdeployer v0.9.1
 	go.flow.arcalot.io/pluginsdk v0.8.0
 	go.flow.arcalot.io/podmandeployer v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcY
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.arcalot.io/assert v1.7.0 h1:PTLyeisNMUKpM9wXRDxResanBhuGOYO1xFK3v5b3FSw=
-go.arcalot.io/assert v1.7.0/go.mod h1:nNmWPoNUHFyrPkNrD2aASm5yPuAfiWdB/4X7Lw3ykHk=
+go.arcalot.io/assert v1.8.0 h1:hGcHMPncQXwQvjj7MbyOu2gg8VIBB00crUJZpeQOjxs=
+go.arcalot.io/assert v1.8.0/go.mod h1:nNmWPoNUHFyrPkNrD2aASm5yPuAfiWdB/4X7Lw3ykHk=
 go.arcalot.io/dgraph v1.2.0 h1:ga71Cry71QSV05bY6qg6EdEpKX0/jan4Zg+aDf89x6U=
 go.arcalot.io/dgraph v1.2.0/go.mod h1:T8h+fVbsjw9trWQtkb5uyl9fABujY8W501UY58t5Ki0=
 go.arcalot.io/exex v0.2.0 h1:u44pjwPwcH57TF8knhaqVZP/1V/KbnRe//pKzMwDpLw=
@@ -135,8 +135,8 @@ go.flow.arcalot.io/deployer v0.5.0 h1:yXYogvL3shNBEEoTx9U9CNbfxuf8777uAH5Vn3hv1Y
 go.flow.arcalot.io/deployer v0.5.0/go.mod h1:whj8wOUursCnfZCt1a7eY5hU3EyOcUG48vM4NeAe5N8=
 go.flow.arcalot.io/dockerdeployer v0.6.1 h1:oRhxXEeOHmXDQVgtYa95tUpw9qc/M//pbeLjdDYMUxc=
 go.flow.arcalot.io/dockerdeployer v0.6.1/go.mod h1:Y5Xfg/Fedw/y4LTV0eiJqnsex1mvTbhtP06LCtFkJyo=
-go.flow.arcalot.io/expressions v0.4.0 h1:fYr4Ud6GA/dAjj2iaewaVOauZPwY6/QHN8F25Q0+w1Y=
-go.flow.arcalot.io/expressions v0.4.0/go.mod h1:WfbAaPUfvAnarly6GO87Cyi6lmWmttMaVS1rR9YDyrU=
+go.flow.arcalot.io/expressions v0.4.1 h1:WOl3DtDcWAmPKupwYxJV3bVYKPoMgAmQbECfiUgv/0s=
+go.flow.arcalot.io/expressions v0.4.1/go.mod h1:FA/50wX1+0iTgW/dFeeE1yOslZSmfBaMNR4IiMYRwxc=
 go.flow.arcalot.io/kubernetesdeployer v0.9.1 h1:AGnJFazehAENXxGMCF0Uc7aG9F0LpvuhoyQFu8deJG0=
 go.flow.arcalot.io/kubernetesdeployer v0.9.1/go.mod h1:yvxT3VwmyrlIi4422pxl02z4QeU2Gvbjg5aQB17Ye4s=
 go.flow.arcalot.io/pluginsdk v0.8.0 h1:cShsshrR17ZFLcbgi3aZvqexLttcp3JISFNqPUPuDvA=

--- a/internal/builtinfunctions/functions.go
+++ b/internal/builtinfunctions/functions.go
@@ -171,7 +171,7 @@ func getFloatToFormattedStringFunction() schema.CallableFunction {
 		"floatToFormattedString",
 		[]schema.Type{
 			schema.NewFloatSchema(nil, nil, nil),
-			schema.NewStringSchema(nil, nil, regexp.MustCompile(`^[beEfFgGxX]$`)),
+			schema.NewStringSchema(nil, nil, regexp.MustCompile(`^[beEfgGxX]$`)),
 			schema.NewIntSchema(nil, nil, nil),
 		},
 		// 'b' format: -ddddp±ddd
@@ -183,7 +183,7 @@ func getFloatToFormattedStringFunction() schema.CallableFunction {
 		schema.NewStringSchema(
 			nil,
 			nil,
-			regexp.MustCompile(`^-?(?:0[xX])?\d+(?:\.\d*)?(?:[pPeE][-+]/d{2,3})?$`)),
+			regexp.MustCompile(`^-?(?:0[xX])?\d+(?:\.\d*)?(?:[pPeE][-+]\d{2,3})?$`)),
 		false,
 		schema.NewDisplayValue(
 			schema.PointerTo("floatToFormattedString"),

--- a/internal/builtinfunctions/functions.go
+++ b/internal/builtinfunctions/functions.go
@@ -192,7 +192,8 @@ func getFloatToFormattedStringFunction() schema.CallableFunction {
 					"specified formatting directive and precision."+
 					" Param 1: the floating point value to convert\n"+
 					" Param 2: the format specifier: 'b', 'e', 'E', 'f', 'g', 'G', 'x', 'X'\n"+
-					" Param 3: the number of digits included in the fraction portion.\n"+
+					" Param 3: the number of digits included in the fraction portion; "+
+					"Specifying -1 will produce the minimum number of digits required to represent the value exactly"+
 					" (See https://pkg.go.dev/strconv@go1.22.0#FormatFloat for details.)",
 			),
 			nil,

--- a/internal/builtinfunctions/functions.go
+++ b/internal/builtinfunctions/functions.go
@@ -17,6 +17,7 @@ func GetFunctions() map[string]schema.CallableFunction {
 	floatToIntFunction := getFloatToIntFunction()
 	intToStringFunction := getIntToStringFunction()
 	floatToStringFunction := getFloatToStringFunction()
+	floatToFormattedStringFunction := getFloatToFormattedStringFunction()
 	booleanToStringFunction := getBooleanToStringFunction()
 	// Parsers, that could fail
 	stringToIntFunction := getStringToIntFunction()
@@ -34,21 +35,22 @@ func GetFunctions() map[string]schema.CallableFunction {
 
 	// Combine in a map
 	allFunctions := map[string]schema.CallableFunction{
-		intToFloatFunction.ID():      intToFloatFunction,
-		floatToIntFunction.ID():      floatToIntFunction,
-		intToStringFunction.ID():     intToStringFunction,
-		floatToStringFunction.ID():   floatToStringFunction,
-		booleanToStringFunction.ID(): booleanToStringFunction,
-		stringToIntFunction.ID():     stringToIntFunction,
-		stringToFloatFunction.ID():   stringToFloatFunction,
-		stringToBoolFunction.ID():    stringToBoolFunction,
-		ceilFunction.ID():            ceilFunction,
-		floorFunction.ID():           floorFunction,
-		roundFunction.ID():           roundFunction,
-		absFunction.ID():             absFunction,
-		toLowerFunction.ID():         toLowerFunction,
-		toUpperFunction.ID():         toUpperFunction,
-		splitStringFunction.ID():     splitStringFunction,
+		intToFloatFunction.ID():             intToFloatFunction,
+		floatToIntFunction.ID():             floatToIntFunction,
+		intToStringFunction.ID():            intToStringFunction,
+		floatToStringFunction.ID():          floatToStringFunction,
+		floatToFormattedStringFunction.ID(): floatToFormattedStringFunction,
+		booleanToStringFunction.ID():        booleanToStringFunction,
+		stringToIntFunction.ID():            stringToIntFunction,
+		stringToFloatFunction.ID():          stringToFloatFunction,
+		stringToBoolFunction.ID():           stringToBoolFunction,
+		ceilFunction.ID():                   ceilFunction,
+		floorFunction.ID():                  floorFunction,
+		roundFunction.ID():                  roundFunction,
+		absFunction.ID():                    absFunction,
+		toLowerFunction.ID():                toLowerFunction,
+		toUpperFunction.ID():                toUpperFunction,
+		splitStringFunction.ID():            splitStringFunction,
 	}
 
 	return allFunctions
@@ -156,6 +158,47 @@ func getFloatToStringFunction() schema.CallableFunction {
 		),
 		func(a float64) string {
 			return strconv.FormatFloat(a, 'f', -1, 64)
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+	return funcSchema
+}
+
+func getFloatToFormattedStringFunction() schema.CallableFunction {
+	funcSchema, err := schema.NewCallableFunction(
+		"floatToFormattedString",
+		[]schema.Type{
+			schema.NewFloatSchema(nil, nil, nil),
+			schema.NewStringSchema(nil, nil, regexp.MustCompile(`^[beEfFgGxX]$`)),
+			schema.NewIntSchema(nil, nil, nil),
+		},
+		// 'b' format: -ddddp±ddd
+		// 'e' format: -d.dddde±dd
+		// 'E' format: -d.ddddE±dd
+		// 'f' format: -ddd.dddd
+		// 'x' format: -0xd.ddddp±ddd
+		// 'X' format: -0Xd.ddddP±ddd
+		schema.NewStringSchema(
+			nil,
+			nil,
+			regexp.MustCompile(`^-?(?:0[xX])?\d+(?:\.\d*)?(?:[pPeE][-+]/d{2,3})?$`)),
+		false,
+		schema.NewDisplayValue(
+			schema.PointerTo("floatToFormattedString"),
+			schema.PointerTo(
+				"Converts a floating point number to a string according to the "+
+					"specified formatting directive and precision."+
+					" Param 1: the floating point value to convert\n"+
+					" Param 2: the format specifier: 'b', 'e', 'E', 'f', 'g', 'G', 'x', 'X'\n"+
+					" Param 3: the number of digits included in the fraction portion.\n"+
+					" (See https://pkg.go.dev/strconv@go1.22.0#FormatFloat for details.)",
+			),
+			nil,
+		),
+		func(f float64, fmt string, precision int64) string {
+			return strconv.FormatFloat(f, fmt[0], int(precision), 64)
 		},
 	)
 	if err != nil {

--- a/internal/builtinfunctions/functions_test.go
+++ b/internal/builtinfunctions/functions_test.go
@@ -151,6 +151,12 @@ var testData = map[string]struct {
 		false,
 		"-Inf",
 	},
+	"float-to-formatted-string-positive-whole": {
+		"floatToFormattedString",
+		[]any{11.0, "f", int64(-1)},
+		false,
+		"11",
+	},
 	"bool-to-string-true": {
 		"boolToString",
 		[]any{true},

--- a/internal/builtinfunctions/functions_test.go
+++ b/internal/builtinfunctions/functions_test.go
@@ -1,6 +1,8 @@
 package builtinfunctions_test
 
 import (
+	"fmt"
+	"go.arcalot.io/assert"
 	"go.flow.arcalot.io/engine/internal/builtinfunctions"
 	"math"
 	"reflect"
@@ -150,12 +152,6 @@ var testData = map[string]struct {
 		[]any{math.Inf(-1)},
 		false,
 		"-Inf",
-	},
-	"float-to-formatted-string-positive-whole": {
-		"floatToFormattedString",
-		[]any{11.0, "f", int64(-1)},
-		false,
-		"11",
 	},
 	"bool-to-string-true": {
 		"boolToString",
@@ -608,5 +604,206 @@ func TestFunctionsBulk(t *testing.T) {
 				t.Fatalf("mismatch for test %q, expected: %v, got: %v", name, testCase.expectedResult, output)
 			}
 		})
+	}
+}
+
+// Test_floatToFormattedString_success tests the success cases for the builtin
+// floatToFormattedString() function.
+func Test_floatToFormattedString_success(t *testing.T) {
+	// The floatToFormattedString() function supports 8 formats, specified by a
+	// single-character string; for each format, we test four different precision
+	// values; for each combination of format and precision, we test ten different
+	// input values, for a total of 290 cases ('b' format ignores the precision,
+	// so we test only one set of values for those cases).  We iterate over each
+	// of the formats, each of the precisions, and each of the input values and
+	// check the output against the expected value.  The expected output values
+	// are the innermost lists in the nested map; the input values (which don't
+	// change with the format and precision) are held in a separate list:  a small
+	// exact (integral) value, a large integral value, a small decimal fraction,
+	// an exact fraction (a negative power of two), an inexact fraction (a
+	// "repeating decimal"), positive and negative infinity, positive and negative
+	// zero, and not-a-number.
+	inputs := []float64{
+		123, 12300, 0.000123, 1.0 / 8.0, 2.0 / 3.0,
+		math.Inf(1), math.Inf(-1), math.NaN(),
+		math.Copysign(0.0, 1.0), math.Copysign(0.0, -1.0),
+	}
+	results := map[string]map[int64][]string{
+		"b": {
+			// The 'b' format ignores the precision, so test only one precision value
+			0: {
+				"8655355533852672p-46", "6761996510822400p-39", "4537899042132550p-65",
+				"4503599627370496p-55", "6004799503160661p-53", "+Inf", "-Inf", "NaN",
+				"0p-1074", "-0p-1074",
+			},
+		},
+		"e": {
+			0: {
+				"1e+02", "1e+04", "1e-04", "1e-01", "7e-01", "+Inf", "-Inf", "NaN",
+				"0e+00", "-0e+00",
+			},
+			1: {
+				"1.2e+02", "1.2e+04", "1.2e-04", "1.2e-01", "6.7e-01", "+Inf", "-Inf",
+				"NaN", "0.0e+00", "-0.0e+00",
+			},
+			-1: {
+				"1.23e+02", "1.23e+04", "1.23e-04", "1.25e-01", "6.666666666666666e-01",
+				"+Inf", "-Inf", "NaN", "0e+00", "-0e+00",
+			},
+			15: {
+				"1.230000000000000e+02", "1.230000000000000e+04", "1.230000000000000e-04",
+				"1.250000000000000e-01", "6.666666666666666e-01", "+Inf", "-Inf", "NaN",
+				"0.000000000000000e+00", "-0.000000000000000e+00",
+			},
+		},
+		"E": {
+			0: {
+				"1E+02", "1E+04", "1E-04", "1E-01", "7E-01", "+Inf", "-Inf", "NaN",
+				"0E+00", "-0E+00",
+			},
+			1: {
+				"1.2E+02", "1.2E+04", "1.2E-04", "1.2E-01", "6.7E-01", "+Inf", "-Inf",
+				"NaN", "0.0E+00", "-0.0E+00",
+			},
+			-1: {
+				"1.23E+02", "1.23E+04", "1.23E-04", "1.25E-01", "6.666666666666666E-01",
+				"+Inf", "-Inf", "NaN", "0E+00", "-0E+00",
+			},
+			15: {
+				"1.230000000000000E+02", "1.230000000000000E+04", "1.230000000000000E-04",
+				"1.250000000000000E-01", "6.666666666666666E-01", "+Inf", "-Inf", "NaN",
+				"0.000000000000000E+00", "-0.000000000000000E+00",
+			},
+		},
+		"f": {
+			0: {"123", "12300", "0", "0", "1", "+Inf", "-Inf", "NaN", "0", "-0"},
+			1: {
+				"123.0", "12300.0", "0.0", "0.1", "0.7", "+Inf", "-Inf", "NaN", "0.0",
+				"-0.0",
+			},
+			-1: {
+				"123", "12300", "0.000123", "0.125", "0.6666666666666666", "+Inf",
+				"-Inf", "NaN", "0", "-0",
+			},
+			15: {
+				"123.000000000000000", "12300.000000000000000", "0.000123000000000",
+				"0.125000000000000", "0.666666666666667", "+Inf", "-Inf", "NaN",
+				"0.000000000000000", "-0.000000000000000",
+			},
+		},
+		"g": {
+			// Uses 'f' format unless the exponent is less than -4, or if the
+			// exponent is greater than 5 and the precision is too small to
+			// represent all the digits, in which case it uses 'e' format; however,
+			// unlike 'e' format, the precision limits the total number of digits
+			// rather than the number of digits to the right of the decimal point.
+			// Also, trailing zeros are removed.
+			0: {
+				"1e+02", "1e+04", "0.0001", "0.1", "0.7", "+Inf", "-Inf", "NaN",
+				"0", "-0",
+			},
+			1: {
+				"1e+02", "1e+04", "0.0001", "0.1", "0.7", "+Inf", "-Inf", "NaN",
+				"0", "-0",
+			},
+			-1: {
+				"123", "12300", "0.000123", "0.125", "0.6666666666666666", "+Inf",
+				"-Inf", "NaN", "0", "-0",
+			},
+			15: {
+				"123", "12300", "0.000123", "0.125", "0.666666666666667", "+Inf",
+				"-Inf", "NaN", "0", "-0",
+			},
+		},
+		"G": {
+			// See note for 'g' format.
+			0: {
+				"1E+02", "1E+04", "0.0001", "0.1", "0.7", "+Inf", "-Inf", "NaN",
+				"0", "-0",
+			},
+			1: {
+				"1E+02", "1E+04", "0.0001", "0.1", "0.7", "+Inf", "-Inf", "NaN",
+				"0", "-0",
+			},
+			-1: {
+				"123", "12300", "0.000123", "0.125", "0.6666666666666666", "+Inf",
+				"-Inf", "NaN", "0", "-0",
+			},
+			15: {
+				"123", "12300", "0.000123", "0.125", "0.666666666666667", "+Inf",
+				"-Inf", "NaN", "0", "-0",
+			},
+		},
+		"x": {
+			0: {
+				"0x1p+07", "0x1p+14", "0x1p-13", "0x1p-03", "0x1p-01", "+Inf",
+				"-Inf", "NaN", "0x0p+00", "-0x0p+00",
+			},
+			1: {
+				"0x1.fp+06", "0x1.8p+13", "0x1.0p-13", "0x1.0p-03", "0x1.5p-01",
+				"+Inf", "-Inf", "NaN", "0x0.0p+00", "-0x0.0p+00",
+			},
+			-1: {
+				"0x1.ecp+06", "0x1.806p+13", "0x1.01f31f46ed246p-13", "0x1p-03",
+				"0x1.5555555555555p-01", "+Inf", "-Inf", "NaN", "0x0p+00", "-0x0p+00",
+			},
+			15: {
+				"0x1.ec0000000000000p+06", "0x1.806000000000000p+13",
+				"0x1.01f31f46ed24600p-13", "0x1.000000000000000p-03",
+				"0x1.555555555555500p-01", "+Inf", "-Inf", "NaN",
+				"0x0.000000000000000p+00", "-0x0.000000000000000p+00",
+			},
+		},
+		"X": {
+			0: {
+				"0X1P+07", "0X1P+14", "0X1P-13", "0X1P-03", "0X1P-01", "+Inf",
+				"-Inf", "NaN", "0X0P+00", "-0X0P+00",
+			},
+			1: {
+				"0X1.FP+06", "0X1.8P+13", "0X1.0P-13", "0X1.0P-03", "0X1.5P-01",
+				"+Inf", "-Inf", "NaN", "0X0.0P+00", "-0X0.0P+00",
+			},
+			-1: {
+				"0X1.ECP+06", "0X1.806P+13", "0X1.01F31F46ED246P-13", "0X1P-03",
+				"0X1.5555555555555P-01", "+Inf", "-Inf", "NaN", "0X0P+00", "-0X0P+00",
+			},
+			15: {
+				"0X1.EC0000000000000P+06", "0X1.806000000000000P+13",
+				"0X1.01F31F46ED24600P-13", "0X1.000000000000000P-03",
+				"0X1.555555555555500P-01", "+Inf", "-Inf", "NaN",
+				"0X0.000000000000000P+00", "-0X0.000000000000000P+00",
+			},
+		},
+	}
+	functionToTest, funcFound :=
+		builtinfunctions.GetFunctions()["floatToFormattedString"]
+	if !funcFound {
+		t.Fatalf("Function \"floatToFormattedString\" not found.")
+	}
+	for f, precisions := range results {
+		for p, expectedValues := range precisions {
+			// Make sure the test provides the same number of inputs and outputs
+			assert.Equals(t, len(expectedValues), len(inputs))
+			for i, expected := range expectedValues {
+				v := inputs[i]
+				name := fmt.Sprintf("floatToFormattedString:%s:%d:%f", f, p, v)
+				rawArguments := []any{v, f, p}
+				expectedValue := expected // Capture loop index in local scope
+				t.Run(name, func(t *testing.T) {
+					output, err := functionToTest.Call(rawArguments)
+					if err != nil {
+						t.Fatalf(
+							"unexpected error in test case %q (%s)",
+							name, err.Error(),
+						)
+					}
+					if value, OK := output.(string); OK {
+						assert.Equals[string](t, value, expectedValue)
+					} else {
+						t.Fatalf("output is not a string: %v", output)
+					}
+				})
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Changes introduced with this PR

This PR adds the `floatToFormattedString()` builtin function to the branch for PR #150.

We can either merge this PR into that one, or we can merge that one into `main` and then merge this one into `main` after it.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).