### PR TITLE
bump dgraph to v1.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.21
 toolchain go1.21.6
 
 require (
-	go.arcalot.io/assert v1.7.0
-	go.arcalot.io/dgraph v1.2.0
+	go.arcalot.io/assert v1.8.0
+	go.arcalot.io/dgraph v1.3.0
 	go.arcalot.io/lang v1.1.0
 	go.arcalot.io/log/v2 v2.1.0
 	go.flow.arcalot.io/deployer v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,12 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.arcalot.io/assert v1.7.0 h1:PTLyeisNMUKpM9wXRDxResanBhuGOYO1xFK3v5b3FSw=
 go.arcalot.io/assert v1.7.0/go.mod h1:nNmWPoNUHFyrPkNrD2aASm5yPuAfiWdB/4X7Lw3ykHk=
+go.arcalot.io/assert v1.8.0 h1:hGcHMPncQXwQvjj7MbyOu2gg8VIBB00crUJZpeQOjxs=
+go.arcalot.io/assert v1.8.0/go.mod h1:nNmWPoNUHFyrPkNrD2aASm5yPuAfiWdB/4X7Lw3ykHk=
 go.arcalot.io/dgraph v1.2.0 h1:ga71Cry71QSV05bY6qg6EdEpKX0/jan4Zg+aDf89x6U=
 go.arcalot.io/dgraph v1.2.0/go.mod h1:T8h+fVbsjw9trWQtkb5uyl9fABujY8W501UY58t5Ki0=
+go.arcalot.io/dgraph v1.3.0 h1:CDj6bhskomgC02roL0TxOgSb8SbkFgQ7hbTH+vJTCDw=
+go.arcalot.io/dgraph v1.3.0/go.mod h1:+Kxc81utiihMSmC1/ttSPGLDlWPpvgOpNxSFmIDPxFM=
 go.arcalot.io/exex v0.2.0 h1:u44pjwPwcH57TF8knhaqVZP/1V/KbnRe//pKzMwDpLw=
 go.arcalot.io/exex v0.2.0/go.mod h1:5zlFr+7vOQNZKYCNOEDdsad+z/dlvXKs2v4kG+v+bQo=
 go.arcalot.io/lang v1.1.0 h1:ugglRKpd3qIMkdghAjKJxsziIgHm8QpxrzZPSXoa08I=


### PR DESCRIPTION
## Changes introduced with this PR

Updating dgraph for fixed and improved mermaid markdown generation.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).