### PR TITLE
Make double-detection test track operations

### DIFF
--- a/internal/util/invalid_serialization_detector.go
+++ b/internal/util/invalid_serialization_detector.go
@@ -11,10 +11,13 @@ func NewInvalidSerializationDetectorSchema() *InvalidSerializationDetectorSchema
 	return &InvalidSerializationDetectorSchema{}
 }
 
-// InvalidSerializationDetectorSchema is a testing type that detects double
-// serialization or double unserialization which could result in corrupted data.
-// The schema tracks the sequence of operations which are performed. The last
-// operation should never match the current operation.
+// InvalidSerializationDetectorSchema is a testing type that detects double-
+// serialization or double-unserialization which could result in corrupted data.
+// The serialization and unserialization methods detect when the operation is
+// performed twice in a row on a single piece of data by examining the input
+// value; they also count the number of overall operations so that we know that
+// the data has been serialized or unserialized at least once (since, if it is
+// never operated on, then it's trivial to claim that it was never doubly done).
 type InvalidSerializationDetectorSchema struct {
 	SerializeCnt   int
 	UnserializeCnt int

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -284,9 +284,10 @@ func TestWithDoubleSerializationDetection(t *testing.T) {
 	// First, get the root object
 	inputSchema := preparedWorkflow.Input()
 	rootObject := inputSchema.Objects()[inputSchema.Root()]
+	errorDetect := util.NewInvalidSerializationDetectorSchema()
 	// Inject the error detector into the object
 	rootObject.PropertiesValue["error_detector"] = schema.NewPropertySchema(
-		util.NewInvalidSerializationDetectorSchema(),
+		errorDetect,
 		nil,
 		true,
 		nil,
@@ -300,7 +301,9 @@ func TestWithDoubleSerializationDetection(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equals(t, outputID, "a")
-	assert.Equals(t, util.InvalidSerializationDetectorOps, []string{"init", "unserialized"})
+	// Confirm that, while we did no double-unserializations or double-serializations,
+	// we did do at least one single one.
+	assert.Equals(t, errorDetect.SerializeCnt+errorDetect.UnserializeCnt > 0, true)
 }
 
 var waitForSerialWorkflowDefinition = `

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -300,6 +300,7 @@ func TestWithDoubleSerializationDetection(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equals(t, outputID, "a")
+	assert.Equals(t, util.InvalidSerializationDetectorOps, []string{"init", "unserialized"})
 }
 
 var waitForSerialWorkflowDefinition = `


### PR DESCRIPTION
## Changes introduced with this PR

This PR modifies #153 to make the schema count the serialization and unserialization operations and to make the counts visible to the test.  It adds an assertion to the test to ensure that the operations are actually performed.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).