### PR TITLE
Correct reference to Renovate bot configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>arcalot/.github:renovate-config"
+    "github>arcalot/.github:renovate-config"
   ]
 }


### PR DESCRIPTION
## Changes introduced with this PR

Our Renovate bot configuration settings don't seem to be working (e.g., it keeps wanting us to use digest hashes instead of SemVer tags).  I think this might be because of the way we pull in the common configuration settings.  So, I'm experimenting with a correction to that.

I'm not really sure how to test this, other than to just go ahead and merge it and see how the bot responds.  However, I'm comfortable with that approach, since this change should not affect anything other than the bot.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).