### PR TITLE
Foreach outputs

### DIFF
--- a/internal/step/foreach/provider.go
+++ b/internal/step/foreach/provider.go
@@ -170,6 +170,9 @@ func (l *forEachProvider) LoadSchema(inputs map[string]any, workflowContext map[
 	if _, ok := outputSchema["success"]; !ok {
 		return nil, fmt.Errorf("the referenced workflow must contain an output named 'success'")
 	}
+	//if len(outputSchema) > 1 {
+	//	return nil, fmt.Errorf("the referenced workflow may only contain a 'success' output")
+	//}
 
 	return &runnableStep{
 		workflow:    preparedWorkflow,

--- a/internal/step/foreach/provider.go
+++ b/internal/step/foreach/provider.go
@@ -170,9 +170,6 @@ func (l *forEachProvider) LoadSchema(inputs map[string]any, workflowContext map[
 	if _, ok := outputSchema["success"]; !ok {
 		return nil, fmt.Errorf("the referenced workflow must contain an output named 'success'")
 	}
-	if len(outputSchema) > 1 {
-		return nil, fmt.Errorf("the referenced workflow may only contain a 'success' output")
-	}
 
 	return &runnableStep{
 		workflow:    preparedWorkflow,

--- a/internal/step/foreach/provider.go
+++ b/internal/step/foreach/provider.go
@@ -170,9 +170,6 @@ func (l *forEachProvider) LoadSchema(inputs map[string]any, workflowContext map[
 	if _, ok := outputSchema["success"]; !ok {
 		return nil, fmt.Errorf("the referenced workflow must contain an output named 'success'")
 	}
-	//if len(outputSchema) > 1 {
-	//	return nil, fmt.Errorf("the referenced workflow may only contain a 'success' output")
-	//}
 
 	return &runnableStep{
 		workflow:    preparedWorkflow,

--- a/internal/step/foreach/provider_example_test.go
+++ b/internal/step/foreach/provider_example_test.go
@@ -43,7 +43,7 @@ outputs:
   success:
     messages: !expr $.steps.greet.outputs.success.data
   failed:
-    error: !expr $.steps.greet.failed.error
+   error: !expr $.steps.greet.failed.error
 `
 
 var subworkflow = `

--- a/internal/step/foreach/provider_example_test.go
+++ b/internal/step/foreach/provider_example_test.go
@@ -43,7 +43,7 @@ outputs:
   success:
     messages: !expr $.steps.greet.outputs.success.data
   failed:
-   error: !expr $.steps.greet.failed.error
+    error: !expr $.steps.greet.failed.error
 `
 
 var subworkflow = `

--- a/internal/step/foreach/provider_example_test.go
+++ b/internal/step/foreach/provider_example_test.go
@@ -3,7 +3,9 @@ package foreach_test
 import (
 	"context"
 	"fmt"
+	"go.arcalot.io/assert"
 	"go.flow.arcalot.io/engine/internal/builtinfunctions"
+	"testing"
 
 	"go.arcalot.io/lang"
 	"go.arcalot.io/log/v2"
@@ -113,6 +115,95 @@ func ExampleNew() {
 	}
 	fmt.Println()
 	// Output: Hello Arca! Hello Lot!
+}
+
+var subworkflow_plugin_template = `
+version: v0.2.0
+input:
+  root: SubRootObject1
+  objects:
+    SubRootObject1:
+      id: SubRootObject1
+      properties: 
+        name:
+          type:
+            type_id: string
+steps:
+  example1:
+    plugin:
+      src: quay.io/arcalot/arcaflow-plugin-template-python
+      deployment_type: image
+    input:
+      name: !expr $.input.name
+outputs:
+  success:
+    name: !expr $.steps.example1.outputs.success.message
+  error:
+    error: !expr $.steps.example1.outputs.error
+`
+
+var foreach_multi_output = `
+version: v0.2.0
+input:
+  root: RootObject
+  objects:
+    RootObject:
+      id: RootObject
+      properties: {}
+steps:
+  subwf_1:
+    kind: foreach
+    items:
+      - name: "test"
+      - name: "test2"
+      - name: "test3"
+    workflow: subwf-1.yaml
+  subwf_2:
+    kind: foreach
+    items: !expr $.steps.subwf_1.outputs.success.data
+    workflow: subwf-1.yaml
+  subwf_3:
+    kind: foreach
+    items: !expr $.steps.subwf_2.outputs.success.data
+    workflow: subwf-1.yaml
+outputs:
+  success:
+    step_3: !expr $.steps.subwf_1.outputs.success
+  error:
+    error1: !expr $.steps.subwf_1.outputs.error
+    error2: !expr $.steps.subwf_2.outputs.error
+    error3: !expr $.steps.subwf_3.outputs.error`
+
+func Test_MultiOutputs(t *testing.T) {
+	logConfig := log.Config{
+		Level:       log.LevelError,
+		Destination: log.DestinationStdout,
+	}
+	logger := log.New(
+		logConfig,
+	)
+	cfg := &config.Config{
+		Log: logConfig,
+	}
+	factories := workflowFactory{
+		config: cfg,
+	}
+	stepRegistry := lang.Must2(registry.New(
+		dummy.New(),
+		lang.Must2(foreach.New(logger, factories.createYAMLParser, factories.createWorkflow)),
+	))
+	factories.stepRegistry = stepRegistry
+	executor := lang.Must2(workflow.NewExecutor(
+		logger,
+		cfg,
+		stepRegistry,
+		builtinfunctions.GetFunctions(),
+	))
+	wf := lang.Must2(workflow.NewYAMLConverter(stepRegistry).FromYAML([]byte(foreach_multi_output)))
+	_, err := executor.Prepare(wf, map[string][]byte{
+		"subwf-1.yaml": []byte(subworkflow_plugin_template),
+	})
+	assert.NoError(t, err)
 }
 
 type workflowFactory struct {


### PR DESCRIPTION
## Changes introduced with this PR

Allow a `foreach`'s sub-workflow to use multiple outputs. For example, either a success with the appropriate output data, or an error that occurred during its execution.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).