### PR TITLE
Upgrade SDK to use ApplyNamespace instead of ApplyScope

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	go.flow.arcalot.io/dockerdeployer v0.7.0
 	go.flow.arcalot.io/expressions v0.4.1
 	go.flow.arcalot.io/kubernetesdeployer v0.9.1
-	go.flow.arcalot.io/pluginsdk v0.11.1
+	go.flow.arcalot.io/pluginsdk v0.12.0
 	go.flow.arcalot.io/podmandeployer v0.11.0
 	go.flow.arcalot.io/pythondeployer v0.6.0
 	go.flow.arcalot.io/testdeployer v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ go.flow.arcalot.io/expressions v0.4.1 h1:WOl3DtDcWAmPKupwYxJV3bVYKPoMgAmQbECfiUg
 go.flow.arcalot.io/expressions v0.4.1/go.mod h1:FA/50wX1+0iTgW/dFeeE1yOslZSmfBaMNR4IiMYRwxc=
 go.flow.arcalot.io/kubernetesdeployer v0.9.1 h1:AGnJFazehAENXxGMCF0Uc7aG9F0LpvuhoyQFu8deJG0=
 go.flow.arcalot.io/kubernetesdeployer v0.9.1/go.mod h1:yvxT3VwmyrlIi4422pxl02z4QeU2Gvbjg5aQB17Ye4s=
-go.flow.arcalot.io/pluginsdk v0.11.1 h1:vutbhJVSqCqVvgYHNTEYa0Hx0p+lxh9HoyFhhC+ui94=
-go.flow.arcalot.io/pluginsdk v0.11.1/go.mod h1:7HafTRTFTYRbJ4sS/Vn0CFrHlaBpEoyOX4oNf612XJM=
+go.flow.arcalot.io/pluginsdk v0.12.0 h1:NJyPMluwtljsNjEEewCeuxE2dGuAJn89KvU52o9OAvU=
+go.flow.arcalot.io/pluginsdk v0.12.0/go.mod h1:7HafTRTFTYRbJ4sS/Vn0CFrHlaBpEoyOX4oNf612XJM=
 go.flow.arcalot.io/podmandeployer v0.11.0 h1:U44YwzIoR3Tpm5ePDVQhycx3ALeu1AYiLxcdQbSvNEQ=
 go.flow.arcalot.io/podmandeployer v0.11.0/go.mod h1:gy+xL1oyyMKkdPUpkPFm94B3E2WySaqMl9sMmdrMk+4=
 go.flow.arcalot.io/pythondeployer v0.6.0 h1:ptAurEJ2u2U127nK6Kk7zTelbkk6ipPqZcwnTmqB9vo=

--- a/internal/util/invalid_serialization_detector.go
+++ b/internal/util/invalid_serialization_detector.go
@@ -19,6 +19,7 @@ func NewInvalidSerializationDetectorSchema() *InvalidSerializationDetectorSchema
 // the data has been serialized or unserialized at least once (since, if it is
 // never operated on, then it's trivial to claim that it was never doubly done).
 type InvalidSerializationDetectorSchema struct {
+	schema.ScalarType
 	SerializeCnt   int
 	UnserializeCnt int
 }
@@ -87,15 +88,6 @@ func (d *InvalidSerializationDetectorSchema) Serialize(data any) (any, error) {
 // SerializeType is string-input-typed version of Serialize.
 func (d *InvalidSerializationDetectorSchema) SerializeType(data string) (any, error) {
 	return d.Serialize(data)
-}
-
-// ApplyScope is for applying a scope to the references. Does not apply to this object.
-func (d *InvalidSerializationDetectorSchema) ApplyScope(_ schema.Scope, _ string) {}
-
-// ValidateReferences validates that all necessary references from scopes have been applied.
-// Does not apply to this object.
-func (d *InvalidSerializationDetectorSchema) ValidateReferences() error {
-	return nil
 }
 
 // TypeID returns the category of type this type is. Returns string because

--- a/workflow/any.go
+++ b/workflow/any.go
@@ -17,11 +17,7 @@ func newAnySchemaWithExpressions() *anySchemaWithExpressions {
 // anySchemaWithExpressions is a wildcard allowing maps, lists, integers, strings, bools, and floats. It also allows
 // expression objects.
 type anySchemaWithExpressions struct {
-	anySchema schema.AnySchema
-}
-
-func (a *anySchemaWithExpressions) ReflectedType() reflect.Type {
-	return a.anySchema.ReflectedType()
+	schema.AnySchema
 }
 
 func (a *anySchemaWithExpressions) Unserialize(data any) (any, error) {
@@ -39,23 +35,11 @@ func (a *anySchemaWithExpressions) ValidateCompatibility(dataOrType any) error {
 		// Assume okay
 		return nil
 	}
-	return a.anySchema.ValidateCompatibility(dataOrType)
+	return a.AnySchema.ValidateCompatibility(dataOrType)
 }
 
 func (a *anySchemaWithExpressions) Serialize(data any) (any, error) {
 	return a.checkAndConvert(data)
-}
-
-func (a *anySchemaWithExpressions) ApplyNamespace(objects map[string]*schema.ObjectSchema, namespace string) {
-	a.anySchema.ApplyNamespace(objects, namespace)
-}
-
-func (a *anySchemaWithExpressions) ValidateReferences() error {
-	return a.anySchema.ValidateReferences()
-}
-
-func (a *anySchemaWithExpressions) TypeID() schema.TypeID {
-	return a.anySchema.TypeID()
 }
 
 func (a *anySchemaWithExpressions) checkAndConvert(data any) (any, error) {
@@ -91,7 +75,7 @@ func (a *anySchemaWithExpressions) checkAndConvert(data any) (any, error) {
 	case reflect.String:
 		fallthrough
 	case reflect.Bool:
-		return a.anySchema.Unserialize(data)
+		return a.AnySchema.Unserialize(data)
 	case reflect.Slice:
 		result := make([]any, t.Len())
 		for i := 0; i < t.Len(); i++ {

--- a/workflow/any.go
+++ b/workflow/any.go
@@ -46,8 +46,8 @@ func (a *anySchemaWithExpressions) Serialize(data any) (any, error) {
 	return a.checkAndConvert(data)
 }
 
-func (a *anySchemaWithExpressions) ApplyScope(scope schema.Scope, namespace string) {
-	a.anySchema.ApplyScope(scope, namespace)
+func (a *anySchemaWithExpressions) ApplyNamespace(objects map[string]*schema.ObjectSchema, namespace string) {
+	a.anySchema.ApplyNamespace(objects, namespace)
 }
 
 func (a *anySchemaWithExpressions) ValidateReferences() error {

--- a/workflow/any.go
+++ b/workflow/any.go
@@ -48,34 +48,6 @@ func (a *anySchemaWithExpressions) checkAndConvert(data any) (any, error) {
 	}
 	t := reflect.ValueOf(data)
 	switch t.Kind() {
-	case reflect.Int:
-		fallthrough
-	case reflect.Uint:
-		fallthrough
-	case reflect.Int8:
-		fallthrough
-	case reflect.Uint8:
-		fallthrough
-	case reflect.Int16:
-		fallthrough
-	case reflect.Uint16:
-		fallthrough
-	case reflect.Int32:
-		fallthrough
-	case reflect.Uint32:
-		fallthrough
-	case reflect.Uint64:
-		fallthrough
-	case reflect.Int64:
-		fallthrough
-	case reflect.Float32:
-		fallthrough
-	case reflect.Float64:
-		fallthrough
-	case reflect.String:
-		fallthrough
-	case reflect.Bool:
-		return a.AnySchema.Unserialize(data)
 	case reflect.Slice:
 		result := make([]any, t.Len())
 		for i := 0; i < t.Len(); i++ {
@@ -102,8 +74,6 @@ func (a *anySchemaWithExpressions) checkAndConvert(data any) (any, error) {
 		}
 		return result, nil
 	default:
-		return nil, &schema.ConstraintError{
-			Message: fmt.Sprintf("unsupported data type for 'any' type: %T", data),
-		}
+		return a.AnySchema.Unserialize(data)
 	}
 }


### PR DESCRIPTION
Fixes #179

## Changes introduced with this PR

This upgrades the SDK. This switches out a few function calls, and utilizes a convenience type for `InvalidSerializationDetector`.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).