### PR TITLE
change method of setting config defaults

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint_and_test:
     name: lint and test
-    uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_lint_and_test.yaml@add-podman
+    uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_lint_and_test.yaml@main
     with:
       go_version: ${{ vars.ARCALOT_GO_VERSION }}
   generate:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint_and_test:
     name: lint and test
-    uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_lint_and_test.yaml@main
+    uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_lint_and_test.yaml@add-podman
     with:
       go_version: ${{ vars.ARCALOT_GO_VERSION }}
   generate:

--- a/cmd/arcaflow/main.go
+++ b/cmd/arcaflow/main.go
@@ -121,6 +121,8 @@ func main() {
 	}
 
 	var configData any
+	// If no config file is passed, we use an empty map to accept the schema defaults
+	configData = make(map[string]any)
 	if len(configFile) > 0 {
 		configFilePath, err := fileCtx.AbsPathByKey(RequiredFileKeyConfig)
 		if err != nil {
@@ -135,9 +137,6 @@ func main() {
 			flag.Usage()
 			os.Exit(ExitCodeInvalidData)
 		}
-	} else {
-		// If no config file is passed, we use an empty map to accept the schema defaults
-		configData = make(map[string]any)
 	}
 
 	cfg, err := config.Load(configData)

--- a/cmd/arcaflow/main.go
+++ b/cmd/arcaflow/main.go
@@ -53,18 +53,6 @@ func main() {
 		Stdout:      os.Stderr,
 	})
 
-	defaultConfig := `
-log:
-  level: info
-deployers:
-  image:
-    deployer_name: podman
-    deployment:
-      imagePullPolicy: IfNotPresent
-logged_outputs:
-  error:
-    level: info`
-
 	configFile := ""
 	input := ""
 	dir := "."
@@ -133,12 +121,7 @@ logged_outputs:
 	}
 
 	var configData any
-	if len(configFile) == 0 {
-		if err := yaml.Unmarshal([]byte(defaultConfig), &configData); err != nil {
-			tempLogger.Errorf("Failed to load default configuration", err)
-			os.Exit(ExitCodeInvalidData)
-		}
-	} else {
+	if len(configFile) > 0 {
 		configFilePath, err := fileCtx.AbsPathByKey(RequiredFileKeyConfig)
 		if err != nil {
 			tempLogger.Errorf("Unable to find configuration file %s (%v)", configFile, err)
@@ -152,6 +135,9 @@ logged_outputs:
 			flag.Usage()
 			os.Exit(ExitCodeInvalidData)
 		}
+	} else {
+		// If no config file is passed, we use an empty map to accept the schema defaults
+		configData = make(map[string]any)
 	}
 
 	cfg, err := config.Load(configData)

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -1,8 +1,9 @@
 package config_test
 
 import (
-	"go.arcalot.io/log/v2"
 	"testing"
+
+	"go.arcalot.io/log/v2"
 
 	"go.arcalot.io/lang"
 	"go.flow.arcalot.io/engine/config"
@@ -19,7 +20,7 @@ var configLoadData = map[string]struct {
 		expectedOutput: &config.Config{
 			TypeHintPlugins: nil,
 			LocalDeployers: map[string]any{
-				"image": map[string]string{"deployer_name": "docker"},
+				"image": map[string]string{"deployer_name": "podman"},
 			},
 			Log: log.Config{
 				Level:       log.LevelInfo,
@@ -35,7 +36,7 @@ log:
 		expectedOutput: &config.Config{
 			TypeHintPlugins: nil,
 			LocalDeployers: map[string]any{
-				"image": map[string]string{"deployer_name": "docker"},
+				"image": map[string]string{"deployer_name": "podman"},
 			},
 			Log: log.Config{
 				Level:       log.LevelDebug,
@@ -70,7 +71,7 @@ plugins:
 				"quay.io/arcalot/example-plugin:latest",
 			},
 			LocalDeployers: map[string]any{
-				"image": map[string]string{"deployer_name": "docker"},
+				"image": map[string]string{"deployer_name": "podman"},
 			},
 			Log: log.Config{
 				Level:       log.LevelInfo,

--- a/config/schema.go
+++ b/config/schema.go
@@ -63,7 +63,7 @@ func getConfigSchema() *schema.TypedScopeSchema[*Config] {
 					nil,
 					nil,
 					nil,
-					schema.PointerTo(`{"image": {"deployer_name": "docker"}}`),
+					schema.PointerTo(`{"image": {"deployer_name": "podman"}}`),
 					nil,
 				),
 				"logged_outputs": schema.NewPropertySchema(

--- a/engine_test.go
+++ b/engine_test.go
@@ -3,8 +3,9 @@ package engine_test
 import (
 	"context"
 	"errors"
-	"go.flow.arcalot.io/engine/loadfile"
 	"testing"
+
+	"go.flow.arcalot.io/engine/loadfile"
 
 	log "go.arcalot.io/log/v2"
 	"go.flow.arcalot.io/engine"
@@ -29,7 +30,7 @@ func createTestEngine(t *testing.T) engine.WorkflowEngine {
 	cfg.Log.Level = log.LevelDebug
 	cfg.Log.Destination = log.DestinationTest
 	cfg.LocalDeployers["image"] = map[string]any{
-		"deployer_name": "docker",
+		"deployer_name": "podman",
 		"deployment": map[string]any{
 			"imagePullPolicy": "IfNotPresent",
 		},


### PR DESCRIPTION
## Changes introduced with this PR

A change in PR #182 used an overly-complicated method of setting the defaults for the configuration. The existing schema definition already had defaults assigned, and in fact that change introduced a bug whereby a partial configuration file passed without a deployer defined will in fact default to docker rather than podman.

This update changes the default in the schema to podman, and it removes the statically-defined default config, opting instead to pass an empty map to the `config.Load` function, which has the effect of using the schema-defined defaults.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).