### PR TITLE
Update the CI's use of the common Go reusable workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,16 +21,18 @@ jobs:
     name: release
     permissions:
       contents: write
+      packages: write
     needs:
       - lint_and_test
       - generate
-    uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_release.yaml@main
+    uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_release.yaml@update-go-lint-and-test  # FIXME:  SHOULD BE @main
     secrets:
-      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      REGISTRY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      REGISTRY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
     with:
       go_version: ${{ vars.ARCALOT_GO_VERSION }}
       for_release: ${{ startsWith(github.event.ref, 'refs/tags/') }}
+      registry: quay.io
   build_python_wheel:
     name: build python wheel
     needs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
     needs:
       - lint_and_test
       - generate
-    uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_release.yaml@update-go-lint-and-test  # FIXME:  SHOULD BE @main
+    uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_release.yaml@main
     secrets:
       REGISTRY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.limgo.json
+++ b/.limgo.json
@@ -1,0 +1,7 @@
+{
+  "statistic": {
+    "excludes": [
+      "mocks/.*"
+    ]
+  }
+}


### PR DESCRIPTION
## Changes introduced with this PR

https://github.com/arcalot/arcaflow-reusable-workflows/pull/24 is updating the common Go reusable workflows to use `limgo` to manage the test coverage, to support mocks in the tests, and to make the release workflow registry-agnostic.  This PR makes the requisite additions to the CI workflow for this repo in order to adapt to those changes.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).