### PR TITLE
Move Workflow Context and Interrupt Handler Instantiation

### DIFF
--- a/cmd/arcaflow/main.go
+++ b/cmd/arcaflow/main.go
@@ -182,11 +182,7 @@ func main() {
 			os.Exit(ExitCodeInvalidData)
 		}
 	}
-
-	os.Exit(runWorkflow(flow, fileCtx, RequiredFileKeyWorkflow, logger, inputData))
-}
-
-func runWorkflow(flow engine.WorkflowEngine, fileCtx loadfile.FileCache, workflowFile string, logger log.Logger, inputData []byte) int {
+	//ctx := context.Background()
 	ctx, cancel := context.WithCancel(context.Background())
 	ctrlC := make(chan os.Signal, 4) // We expect up to three ctrl-C inputs. Plus one extra to buffer in case.
 	signal.Notify(ctrlC, os.Interrupt)
@@ -196,6 +192,20 @@ func runWorkflow(flow engine.WorkflowEngine, fileCtx loadfile.FileCache, workflo
 		close(ctrlC) // Ensure that the goroutine exits
 		cancel()
 	}()
+
+	os.Exit(runWorkflow(ctx, flow, fileCtx, RequiredFileKeyWorkflow, logger, inputData))
+}
+
+func runWorkflow(ctx context.Context, flow engine.WorkflowEngine, fileCtx loadfile.FileCache, workflowFile string, logger log.Logger, inputData []byte) int {
+	//ctx, cancel := context.WithCancel(ctx)
+	//ctrlC := make(chan os.Signal, 4) // We expect up to three ctrl-C inputs. Plus one extra to buffer in case.
+	//signal.Notify(ctrlC, os.Interrupt)
+	//
+	//go handleOSInterrupt(ctrlC, cancel, logger)
+	//defer func() {
+	//	close(ctrlC) // Ensure that the goroutine exits
+	//	cancel()
+	//}()
 
 	workflow, err := flow.Parse(fileCtx, workflowFile)
 	if err != nil {

--- a/cmd/arcaflow/main.go
+++ b/cmd/arcaflow/main.go
@@ -182,7 +182,7 @@ func main() {
 			os.Exit(ExitCodeInvalidData)
 		}
 	}
-	//ctx := context.Background()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	ctrlC := make(chan os.Signal, 4) // We expect up to three ctrl-C inputs. Plus one extra to buffer in case.
 	signal.Notify(ctrlC, os.Interrupt)
@@ -197,16 +197,6 @@ func main() {
 }
 
 func runWorkflow(ctx context.Context, flow engine.WorkflowEngine, fileCtx loadfile.FileCache, workflowFile string, logger log.Logger, inputData []byte) int {
-	//ctx, cancel := context.WithCancel(ctx)
-	//ctrlC := make(chan os.Signal, 4) // We expect up to three ctrl-C inputs. Plus one extra to buffer in case.
-	//signal.Notify(ctrlC, os.Interrupt)
-	//
-	//go handleOSInterrupt(ctrlC, cancel, logger)
-	//defer func() {
-	//	close(ctrlC) // Ensure that the goroutine exits
-	//	cancel()
-	//}()
-
 	workflow, err := flow.Parse(fileCtx, workflowFile)
 	if err != nil {
 		logger.Errorf("Invalid workflow (%v)", err)


### PR DESCRIPTION
## Changes introduced with this PR

Moves the context and interrupt handler instantiation to the main function, thus adding a `ctx context.Context` parameter to `runWorkflow()`. This is to facilitate the isolation of the calls to `WorkflowEngine.Parse()` and `Workflow.Run()`, so that artifact cleanup has a chance to occur no matter where the execution stops in the code path.

It's not ready.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).