### PR TITLE
Make Namespace Behavior Public

### DIFF
--- a/internal/util/stringers.go
+++ b/internal/util/stringers.go
@@ -1,0 +1,17 @@
+package util
+
+import "go.flow.arcalot.io/pluginsdk/schema"
+
+// BuildNamespaceString creates a human-readable string representation of the
+// namespace scoped objects.
+func BuildNamespaceString(allNamespaces map[string]map[string]*schema.ObjectSchema) string {
+	availableObjects := ""
+	for namespace, objects := range allNamespaces {
+		availableObjects += "\n\t" + namespace + ":"
+		for objectID := range objects {
+			availableObjects += " " + objectID
+		}
+	}
+	availableObjects += "\n"
+	return availableObjects
+}

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"go.flow.arcalot.io/engine/internal/util"
 	"reflect"
 	"strings"
 
@@ -357,22 +358,8 @@ func applyAllNamespaces(allNamespaces map[string]map[string]*schema.ObjectSchema
 	return fmt.Errorf(
 		"error validating references for workflow input (%w)\nAvailable namespaces and objects:%s",
 		err,
-		BuildNamespaceString(allNamespaces),
+		util.BuildNamespaceString(allNamespaces),
 	)
-}
-
-// BuildNamespaceString creates a human-readable string representation of the
-// namespace scoped objects.
-func BuildNamespaceString(allNamespaces map[string]map[string]*schema.ObjectSchema) string {
-	availableObjects := ""
-	for namespace, objects := range allNamespaces {
-		availableObjects += "\n\t" + namespace + ":"
-		for objectID := range objects {
-			availableObjects += " " + objectID
-		}
-	}
-	availableObjects += "\n" // Since this is a multi-line error message, ending with a newline is clearer.
-	return availableObjects
 }
 
 func addOutputNamespaces(allNamespaces map[string]map[string]*schema.ObjectSchema, stage step.LifecycleStageWithSchema, prefix string) {

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -313,10 +313,7 @@ func (e *executor) processSteps(
 	return runnableSteps, stepOutputProperties, stepLifecycles, stepRunData, nil
 }
 
-func applyLifecycleScopes(
-	stepLifecycles map[string]step.Lifecycle[step.LifecycleStageWithSchema],
-	typedInput schema.Scope,
-) error {
+func BuildNamespacedScopes(stepLifecycles map[string]step.Lifecycle[step.LifecycleStageWithSchema]) map[string]map[string]*schema.ObjectSchema {
 	allNamespaces := make(map[string]map[string]*schema.ObjectSchema)
 	for workflowStepID, stepLifecycle := range stepLifecycles {
 		for _, stage := range stepLifecycle.Stages {
@@ -329,7 +326,14 @@ func applyLifecycleScopes(
 			addOutputNamespacedScopes(allNamespaces, stage, prefix+"outputs.")
 		}
 	}
-	return applyAllNamespaces(allNamespaces, typedInput)
+	return allNamespaces
+}
+
+func applyLifecycleScopes(
+	stepLifecycles map[string]step.Lifecycle[step.LifecycleStageWithSchema],
+	typedInput schema.Scope,
+) error {
+	return applyAllNamespaces(BuildNamespacedScopes(stepLifecycles), typedInput)
 }
 
 // applyAllNamespaces applies all namespaces to the given scope.

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -314,7 +314,7 @@ func (e *executor) processSteps(
 }
 
 // BuildNamespaces creates a namespaced collection of objects for the inputs
-// and outputs of each step's lifecycle's stage.
+// and outputs of each stage in the step's lifecycles.
 func BuildNamespaces(stepLifecycles map[string]step.Lifecycle[step.LifecycleStageWithSchema]) map[string]map[string]*schema.ObjectSchema {
 	allNamespaces := make(map[string]map[string]*schema.ObjectSchema)
 	for workflowStepID, stepLifecycle := range stepLifecycles {

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -361,6 +361,8 @@ func applyAllNamespaces(allNamespaces map[string]map[string]*schema.ObjectSchema
 	)
 }
 
+// BuildNamespaceString creates a human-readable string representation of the
+// namespace scoped objects.
 func BuildNamespaceString(allNamespaces map[string]map[string]*schema.ObjectSchema) string {
 	availableObjects := ""
 	for namespace, objects := range allNamespaces {

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -75,6 +75,7 @@ type ExecutableWorkflow interface {
 
 	// Namespaces returns a namespaced collection of objects for the inputs
 	// and outputs of each stage in the step's lifecycles.
+	// It maps namespace id (path) to object id to object schema.
 	Namespaces() map[string]map[string]*schema.ObjectSchema
 }
 

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -320,6 +320,7 @@ func (e *executor) processSteps(
 
 // BuildNamespaces creates a namespaced collection of objects for the inputs
 // and outputs of each stage in the step's lifecycles.
+// It maps namespace id (path) to object id to object schema.
 func BuildNamespaces(stepLifecycles map[string]step.Lifecycle[step.LifecycleStageWithSchema]) map[string]map[string]*schema.ObjectSchema {
 	allNamespaces := make(map[string]map[string]*schema.ObjectSchema)
 	for workflowStepID, stepLifecycle := range stepLifecycles {

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -313,6 +313,8 @@ func (e *executor) processSteps(
 	return runnableSteps, stepOutputProperties, stepLifecycles, stepRunData, nil
 }
 
+// BuildNamespacedScopes creates a map of a workflow's steps' lifecycles to
+// the object schemas that exist during that lifecycle.
 func BuildNamespacedScopes(stepLifecycles map[string]step.Lifecycle[step.LifecycleStageWithSchema]) map[string]map[string]*schema.ObjectSchema {
 	allNamespaces := make(map[string]map[string]*schema.ObjectSchema)
 	for workflowStepID, stepLifecycle := range stepLifecycles {

--- a/workflow/executor_unit_test.go
+++ b/workflow/executor_unit_test.go
@@ -61,7 +61,7 @@ var testLifecycleStage = step.LifecycleStageWithSchema{
 func TestAddOutputNamespacedScopes(t *testing.T) {
 	allNamespaces := make(map[string]map[string]*schema.ObjectSchema)
 	namespacePrefix := "TEST_PREFIX_"
-	addOutputNamespacedScopes(allNamespaces, testLifecycleStage, namespacePrefix)
+	addOutputNamespaces(allNamespaces, testLifecycleStage, namespacePrefix)
 	expectedNamespace := namespacePrefix + "outputC"
 	assert.Equals(t, len(allNamespaces), 1)
 	assert.MapContainsKey(t, expectedNamespace, allNamespaces)
@@ -76,7 +76,7 @@ func TestAddInputNamespacedScopes(t *testing.T) {
 		"listA":  "testObjectB",
 	}
 
-	addInputNamespacedScopes(allNamespaces, testLifecycleStage, namespacePrefix)
+	addInputNamespaces(allNamespaces, testLifecycleStage, namespacePrefix)
 	assert.Equals(t, len(allNamespaces), 2)
 	for expectedInput, expectedObject := range expectedInputs {
 		expectedNamespace := namespacePrefix + expectedInput
@@ -459,7 +459,7 @@ func TestApplyLifecycleScopes_Basic(t *testing.T) {
 			},
 		),
 	)
-	assert.NoError(t, applyLifecycleScopes(stepLifecycles, testScope))
+	assert.NoError(t, applyLifecycleNamespaces(stepLifecycles, testScope))
 	assert.NoError(t, testScope.ValidateReferences())
 	assert.NotNil(t, ref1Schema.GetObject())
 	assert.NotNil(t, ref2Schema.GetObject())

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -55,6 +55,12 @@ func (e *executableWorkflow) DAG() dgraph.DirectedGraph[*DAGItem] {
 	return e.dag
 }
 
+// Namespaces returns a namespaced collection of objects for the inputs
+// and outputs of each stage in the step's lifecycles.
+func (e *executableWorkflow) Namespaces() map[string]map[string]*schema.ObjectSchema {
+	return BuildNamespaces(e.lifecycles)
+}
+
 // Execute runs the workflow with the specified input. You can use the context variable to abort the workflow execution
 // (e.g. when the user presses Ctrl+C).
 func (e *executableWorkflow) Execute(ctx context.Context, serializedInput any) (outputID string, outputData any, err error) { //nolint:gocognit

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -57,6 +57,7 @@ func (e *executableWorkflow) DAG() dgraph.DirectedGraph[*DAGItem] {
 
 // Namespaces returns a namespaced collection of objects for the inputs
 // and outputs of each stage in the step's lifecycles.
+// It maps namespace id (path) to object id to object schema.
 func (e *executableWorkflow) Namespaces() map[string]map[string]*schema.ObjectSchema {
 	return BuildNamespaces(e.lifecycles)
 }


### PR DESCRIPTION
## Changes introduced with this PR

Export namespace building behavior so that it is available to other packages within the arcaflow engine.

This will functionality will be used by the `ExecutableWorkflow` interface which will be implemented in a subsequent pull request.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).