### PR TITLE
Add random numbering to the loadfile test

### DIFF
--- a/loadfile/loadfile_test.go
+++ b/loadfile/loadfile_test.go
@@ -23,6 +23,7 @@ func Test_LoadContext(t *testing.T) {
 	assert.NoError(t, os.MkdirAll(testdir, os.ModePerm))
 
 	// Randomize the number to prevent collisions when running the test many times with -count
+	//nolint:gosec  // This is not related to security.
 	randSeed := strconv.Itoa(rand.Int())
 
 	// create a directory

--- a/loadfile/loadfile_test.go
+++ b/loadfile/loadfile_test.go
@@ -23,6 +23,7 @@ func Test_LoadContext(t *testing.T) {
 	// create a directory
 	dirPrefix := "mydir"
 	dirPath, err := os.MkdirTemp(testdir, dirPrefix+"*")
+	assert.NoError(t, err)
 
 	// create a file
 	filenamePrefix := "myfile"

--- a/loadfile/loadfile_test.go
+++ b/loadfile/loadfile_test.go
@@ -4,8 +4,10 @@ import (
 	"go.arcalot.io/assert"
 	"go.flow.arcalot.io/engine/loadfile"
 	"log"
+	"math/rand"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 )
 
@@ -20,13 +22,16 @@ func Test_LoadContext(t *testing.T) {
 	testdir := filepath.Join(TestDir, "load-ctx")
 	assert.NoError(t, os.MkdirAll(testdir, os.ModePerm))
 
+	// Randomize the number to prevent collisions when running the test many times with -count
+	randSeed := strconv.Itoa(rand.Int())
+
 	// create a directory
-	dirname := "mydir"
+	dirname := "mydir" + randSeed
 	dirpath := filepath.Join(testdir, dirname)
 	assert.NoError(t, os.MkdirAll(dirpath, os.ModePerm))
 
 	// create a file
-	filename := "myfile"
+	filename := "myfile" + randSeed
 	filePath := filepath.Join(testdir, filename)
 	f, err := os.Create(filepath.Clean(filePath))
 	assert.NoError(t, err)

--- a/loadfile/loadfile_test.go
+++ b/loadfile/loadfile_test.go
@@ -22,12 +22,12 @@ func Test_LoadContext(t *testing.T) {
 
 	// create a directory
 	dirPrefix := "mydir"
-	dirPath, err := os.MkdirTemp(testdir, dirPrefix+"*")
+	dirPath, err := os.MkdirTemp(testdir, dirPrefix)
 	assert.NoError(t, err)
 
 	// create a file
 	filenamePrefix := "myfile"
-	f, err := os.CreateTemp(dirPath, filenamePrefix+"*")
+	f, err := os.CreateTemp(dirPath, filenamePrefix)
 	assert.NoError(t, err)
 	filePath := f.Name()
 	assert.NoError(t, f.Close())

--- a/loadfile/loadfile_test.go
+++ b/loadfile/loadfile_test.go
@@ -21,8 +21,7 @@ func Test_LoadContext(t *testing.T) {
 	assert.NoError(t, os.MkdirAll(testdir, os.ModePerm))
 
 	// create a directory
-	dirPrefix := "mydir"
-	dirPath, err := os.MkdirTemp(testdir, dirPrefix)
+	dirPath, err := os.MkdirTemp(testdir, "mydir")
 	assert.NoError(t, err)
 
 	// create a file

--- a/loadfile/loadfile_test.go
+++ b/loadfile/loadfile_test.go
@@ -25,8 +25,7 @@ func Test_LoadContext(t *testing.T) {
 	assert.NoError(t, err)
 
 	// create a file
-	filenamePrefix := "myfile"
-	f, err := os.CreateTemp(dirPath, filenamePrefix)
+	f, err := os.CreateTemp(dirPath, "myfile")
 	assert.NoError(t, err)
 	filePath := f.Name()
 	assert.NoError(t, f.Close())


### PR DESCRIPTION
## Changes introduced with this PR

I always needed to comment out this test case when running all tests due to the issues running this test with count > 1.
This uses the standard library temp file randomization. Tested with 20,000 count.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).