### PR TITLE
Use unenforced id feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	go.flow.arcalot.io/dockerdeployer v0.7.3
 	go.flow.arcalot.io/expressions v0.4.3
 	go.flow.arcalot.io/kubernetesdeployer v0.9.3
-	go.flow.arcalot.io/pluginsdk v0.12.5
+	go.flow.arcalot.io/pluginsdk v0.13.0
 	go.flow.arcalot.io/podmandeployer v0.11.3
 	go.flow.arcalot.io/pythondeployer v0.6.1
 	go.flow.arcalot.io/testdeployer v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ go.flow.arcalot.io/expressions v0.4.3 h1:0BRRghutHp0sctsITHe/A1le0yYiJtKNTxm27T+
 go.flow.arcalot.io/expressions v0.4.3/go.mod h1:UORX78N4ep71wOzNXdIo/UY+6SdDD0id0mvuRNEQMeM=
 go.flow.arcalot.io/kubernetesdeployer v0.9.3 h1:XKiqmCqXb6ZLwP5IQTAKS/gJHpq0Ub/yEjCfgAwQF2A=
 go.flow.arcalot.io/kubernetesdeployer v0.9.3/go.mod h1:DtB6HR7HBt/HA1vME0faIpOQ/lhfBJjL6OAGgT3Bu/Q=
-go.flow.arcalot.io/pluginsdk v0.12.5 h1:9b3pKeoHCRH4yF2xIdu8L7SqNUYJFxTsk8L5+inR1xw=
-go.flow.arcalot.io/pluginsdk v0.12.5/go.mod h1:5kMCVigP89J/KU5T72EAczQXPWXZkRfUFcpnIkOECV8=
+go.flow.arcalot.io/pluginsdk v0.13.0 h1:bZqohrDkyAHsWmFJbyvPkjqUALPNJqObefVQrmYqUTw=
+go.flow.arcalot.io/pluginsdk v0.13.0/go.mod h1:YPVTOQ0BGn72RR4YkhsFXznaejfR5HN+or05t23Nqns=
 go.flow.arcalot.io/podmandeployer v0.11.3 h1:I/p6PNWj1zOUEQltIgSzS/LSmyh+YXvR7nol7iYW1do=
 go.flow.arcalot.io/podmandeployer v0.11.3/go.mod h1:3IdybYWxt9C+Woi2odsU04xiO7+fVODBij7xKCIg2Ms=
 go.flow.arcalot.io/pythondeployer v0.6.1 h1:IyaA9BVfHJ2fhC+fNfT6VicrtRGFlZOlSaAVGGPwo1E=

--- a/internal/builtinfunctions/functions.go
+++ b/internal/builtinfunctions/functions.go
@@ -623,7 +623,7 @@ func HandleTypeSchemaCombine(inputType []schema.Type) (schema.Type, error) {
 	constantsTypeArg := inputType[1]
 	combinedObjectName := schemaName(itemType) + CombinedObjIDDelimiter + schemaName(constantsTypeArg)
 	return schema.NewListSchema(
-		schema.NewObjectSchema(
+		schema.NewUnenforcedIDObjectSchema(
 			combinedObjectName,
 			map[string]*schema.PropertySchema{
 				CombinedObjPropertyItemName:     schema.NewPropertySchema(itemType, nil, false, nil, nil, nil, nil, nil),

--- a/internal/builtinfunctions/functions_test.go
+++ b/internal/builtinfunctions/functions_test.go
@@ -949,6 +949,7 @@ func TestHandleTypeSchemaCombine(t *testing.T) {
 			listItemObj, isObj := schema.ConvertToObjectSchema(outputType.(*schema.ListSchema).ItemsValue)
 			assert.Equals(t, isObj, true)
 			assert.Equals(t, listItemObj.ID(), lclInput.expectedResult)
+			assert.Equals(t, listItemObj.IDUnenforced(), true)
 		})
 	}
 }


### PR DESCRIPTION
## Changes introduced with this PR

This PR enables the ID unenforced feature for the `bindConstants` function.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).