### PR TITLE
Oneof Outputs for Graceful Handling of Disabled Steps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	go.arcalot.io/assert v1.8.0
-	go.arcalot.io/dgraph v1.5.0
+	go.arcalot.io/dgraph v1.6.0
 	go.arcalot.io/lang v1.1.0
 	go.arcalot.io/log/v2 v2.2.0
 	go.flow.arcalot.io/deployer v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.arcalot.io/assert v1.8.0 h1:hGcHMPncQXwQvjj7MbyOu2gg8VIBB00crUJZpeQOjxs=
 go.arcalot.io/assert v1.8.0/go.mod h1:nNmWPoNUHFyrPkNrD2aASm5yPuAfiWdB/4X7Lw3ykHk=
-go.arcalot.io/dgraph v1.5.0 h1:6cGlxLzmmehJoD/nj0Hkql7uh90EU0A0GtZhGYkr28M=
-go.arcalot.io/dgraph v1.5.0/go.mod h1:+Kxc81utiihMSmC1/ttSPGLDlWPpvgOpNxSFmIDPxFM=
+go.arcalot.io/dgraph v1.6.0 h1:mJFZ1vdPEg3KtqyhNqYtWVAkxxWBWoJVUFZQ2Z4mbvE=
+go.arcalot.io/dgraph v1.6.0/go.mod h1:+Kxc81utiihMSmC1/ttSPGLDlWPpvgOpNxSFmIDPxFM=
 go.arcalot.io/exex v0.2.0 h1:u44pjwPwcH57TF8knhaqVZP/1V/KbnRe//pKzMwDpLw=
 go.arcalot.io/exex v0.2.0/go.mod h1:5zlFr+7vOQNZKYCNOEDdsad+z/dlvXKs2v4kG+v+bQo=
 go.arcalot.io/lang v1.1.0 h1:ugglRKpd3qIMkdghAjKJxsziIgHm8QpxrzZPSXoa08I=

--- a/internal/infer/infer.go
+++ b/internal/infer/infer.go
@@ -76,6 +76,13 @@ func Type(
 		}
 		return expressionType, nil
 	}
+	if oneOfExpression, ok := data.(OneOfExpression); ok {
+		oneOfType, err := oneOfExpression.Type(internalDataModel, functions, workflowContext)
+		if err != nil {
+			return nil, fmt.Errorf("failed to evaluate type of expression %s (%w)", oneOfExpression.String(), err)
+		}
+		return oneOfType, nil
+	}
 	v := reflect.ValueOf(data)
 	switch v.Kind() {
 	case reflect.Map:

--- a/internal/infer/infer.go
+++ b/internal/infer/infer.go
@@ -65,7 +65,7 @@ func Scope(
 // Type attempts to infer the data model from the data, possibly evaluating expressions.
 func Type(
 	data any,
-	internalDataModel *schema.ScopeSchema,
+	internalDataModel schema.Scope,
 	functions map[string]schema.Function,
 	workflowContext map[string][]byte,
 ) (schema.Type, error) {
@@ -76,7 +76,7 @@ func Type(
 		}
 		return expressionType, nil
 	}
-	if oneOfExpression, ok := data.(OneOfExpression); ok {
+	if oneOfExpression, ok := data.(*OneOfExpression); ok {
 		oneOfType, err := oneOfExpression.Type(internalDataModel, functions, workflowContext)
 		if err != nil {
 			return nil, fmt.Errorf("failed to evaluate type of expression %s (%w)", oneOfExpression.String(), err)
@@ -139,7 +139,7 @@ func Type(
 // mapType infers the type of a map value.
 func mapType(
 	v reflect.Value,
-	internalDataModel *schema.ScopeSchema,
+	internalDataModel schema.Scope,
 	functions map[string]schema.Function,
 	workflowContext map[string][]byte,
 ) (schema.Type, error) {
@@ -193,7 +193,7 @@ func mapType(
 
 func objectType(
 	value reflect.Value,
-	internalDataModel *schema.ScopeSchema,
+	internalDataModel schema.Scope,
 	functions map[string]schema.Function,
 	workflowContext map[string][]byte,
 ) (schema.Type, error) {
@@ -223,7 +223,7 @@ func objectType(
 // sliceType tries to infer the type of a slice.
 func sliceType(
 	v reflect.Value,
-	internalDataModel *schema.ScopeSchema,
+	internalDataModel schema.Scope,
 	functions map[string]schema.Function,
 	workflowContext map[string][]byte,
 ) (schema.Type, error) {
@@ -244,7 +244,7 @@ func sliceType(
 
 func sliceItemType(
 	values []reflect.Value,
-	internalDataModel *schema.ScopeSchema,
+	internalDataModel schema.Scope,
 	functions map[string]schema.Function,
 	workflowContext map[string][]byte,
 ) (schema.Type, error) {

--- a/internal/infer/infer.go
+++ b/internal/infer/infer.go
@@ -148,9 +148,7 @@ func mapType(
 		return nil, fmt.Errorf("failed to infer map key type (%w)", err)
 	}
 	switch keyType.TypeID() {
-	case schema.TypeIDString:
-		fallthrough
-	case schema.TypeIDStringEnum:
+	case schema.TypeIDString, schema.TypeIDStringEnum:
 		return objectType(v, internalDataModel, functions, workflowContext)
 	case schema.TypeIDInt:
 	case schema.TypeIDIntEnum:
@@ -214,7 +212,7 @@ func objectType(
 			nil,
 		)
 	}
-	return schema.NewObjectSchema(
+	return schema.NewUnenforcedIDObjectSchema(
 		generateRandomObjectID("inferred_schema"),
 		properties,
 	), nil

--- a/internal/infer/infer.go
+++ b/internal/infer/infer.go
@@ -69,20 +69,21 @@ func Type(
 	functions map[string]schema.Function,
 	workflowContext map[string][]byte,
 ) (schema.Type, error) {
-	if expression, ok := data.(expressions.Expression); ok {
-		expressionType, err := expression.Type(internalDataModel, functions, workflowContext)
+	switch expr := data.(type) {
+	case expressions.Expression:
+		expressionType, err := expr.Type(internalDataModel, functions, workflowContext)
 		if err != nil {
-			return nil, fmt.Errorf("failed to evaluate type of expression %s (%w)", expression.String(), err)
+			return nil, fmt.Errorf("failed to evaluate type of expression %s (%w)", expr.String(), err)
 		}
 		return expressionType, nil
-	}
-	if oneOfExpression, ok := data.(*OneOfExpression); ok {
-		oneOfType, err := oneOfExpression.Type(internalDataModel, functions, workflowContext)
+	case *OneOfExpression:
+		oneOfType, err := expr.Type(internalDataModel, functions, workflowContext)
 		if err != nil {
-			return nil, fmt.Errorf("failed to evaluate type of expression %s (%w)", oneOfExpression.String(), err)
+			return nil, fmt.Errorf("failed to evaluate type of expression %s (%w)", expr.String(), err)
 		}
 		return oneOfType, nil
 	}
+
 	v := reflect.ValueOf(data)
 	switch v.Kind() {
 	case reflect.Map:

--- a/internal/infer/infer_test.go
+++ b/internal/infer/infer_test.go
@@ -29,7 +29,7 @@ var testOneOf = infer.OneOfExpression{
 			"value-2": lang.Must2(expressions.New("$.a")),
 		},
 	},
-	Node: "n/a",
+	NodePath: "n/a",
 }
 
 var testData = []testEntry{

--- a/internal/infer/infer_test.go
+++ b/internal/infer/infer_test.go
@@ -2,6 +2,9 @@ package infer_test
 
 import (
 	"fmt"
+	"go.arcalot.io/assert"
+	"go.arcalot.io/lang"
+	"go.flow.arcalot.io/expressions"
 	"testing"
 
 	"go.flow.arcalot.io/engine/internal/infer"
@@ -11,14 +14,29 @@ import (
 type testEntry struct {
 	name               string
 	input              any
+	dataModel          schema.Scope
 	expectedOutputType schema.TypeID
 	validate           func(t schema.Type) error
+}
+
+var testOneOf = infer.OneOfExpression{
+	Discriminator: "option",
+	Options: map[string]any{
+		"a": map[string]any{
+			"value-1": 1,
+		},
+		"b": map[string]any{
+			"value-2": lang.Must2(expressions.New("$.a")),
+		},
+	},
+	Node: "n/a",
 }
 
 var testData = []testEntry{
 	{
 		"string",
 		"foo",
+		nil,
 		schema.TypeIDString,
 		func(t schema.Type) error {
 			return nil
@@ -30,6 +48,7 @@ var testData = []testEntry{
 			"foo": "bar",
 			"baz": 42,
 		},
+		nil,
 		schema.TypeIDObject,
 		func(t schema.Type) error {
 			objectSchema := t.(*schema.ObjectSchema)
@@ -46,6 +65,7 @@ var testData = []testEntry{
 	{
 		"slice",
 		[]string{"foo"},
+		nil,
 		schema.TypeIDList,
 		func(t schema.Type) error {
 			listType := t.(*schema.ListSchema)
@@ -55,19 +75,95 @@ var testData = []testEntry{
 			return nil
 		},
 	},
+	{
+		"expression-1",
+		lang.Must2(expressions.New("$.a")),
+		schema.NewScopeSchema(
+			schema.NewObjectSchema("root", map[string]*schema.PropertySchema{
+				"a": schema.NewPropertySchema(
+					schema.NewStringSchema(nil, nil, nil),
+					nil,
+					true,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+				),
+			}),
+		),
+		schema.TypeIDString,
+		func(t schema.Type) error {
+			return nil
+		},
+	},
+	{
+		"oneof-expression",
+		&testOneOf,
+		schema.NewScopeSchema(
+			schema.NewObjectSchema("root", map[string]*schema.PropertySchema{
+				"a": schema.NewPropertySchema(
+					schema.NewStringSchema(nil, nil, nil),
+					nil,
+					true,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+				),
+			}),
+		),
+		schema.TypeIDOneOfString,
+		func(t schema.Type) error {
+			return t.ValidateCompatibility(
+				schema.NewOneOfStringSchema[any](
+					map[string]schema.Object{
+						"a": schema.NewObjectSchema("n/a", map[string]*schema.PropertySchema{
+							"value-1": schema.NewPropertySchema(
+								schema.NewIntSchema(nil, nil, nil),
+								nil,
+								true,
+								nil,
+								nil,
+								nil,
+								nil,
+								nil,
+							),
+						}),
+						"b": schema.NewObjectSchema("n/a", map[string]*schema.PropertySchema{
+							"value-2": schema.NewPropertySchema(
+								schema.NewStringSchema(nil, nil, nil),
+								nil,
+								true,
+								nil,
+								nil,
+								nil,
+								nil,
+								nil,
+							),
+						}),
+					},
+					"option",
+					false,
+				),
+			)
+		},
+	},
 }
 
 func TestInfer(t *testing.T) {
 	for _, entry := range testData {
 		entry := entry
 		t.Run(entry.name, func(t *testing.T) {
-			inferredType, err := infer.Type(entry.input, nil, nil, nil)
+			inferredType, err := infer.Type(entry.input, entry.dataModel, nil, nil)
 			if err != nil {
 				t.Fatalf("%v", err)
 			}
 			if inferredType.TypeID() != entry.expectedOutputType {
 				t.Fatalf("Incorrect type inferred: %s", inferredType.TypeID())
 			}
+			assert.NoError(t, entry.validate(inferredType))
 		})
 	}
 

--- a/internal/infer/infer_test.go
+++ b/internal/infer/infer_test.go
@@ -38,7 +38,7 @@ var testData = []testEntry{
 		"foo",
 		nil,
 		schema.TypeIDString,
-		func(t schema.Type) error {
+		func(_ schema.Type) error {
 			return nil
 		},
 	},
@@ -93,7 +93,7 @@ var testData = []testEntry{
 			}),
 		),
 		schema.TypeIDString,
-		func(t schema.Type) error {
+		func(_ schema.Type) error {
 			return nil
 		},
 	},

--- a/internal/infer/oneof_expression.go
+++ b/internal/infer/oneof_expression.go
@@ -11,6 +11,7 @@ import (
 type OneOfExpression struct {
 	Discriminator string
 	Options       map[string]any
+	Node          string
 }
 
 func (o *OneOfExpression) String() string {
@@ -19,7 +20,7 @@ func (o *OneOfExpression) String() string {
 
 // Type returns the OneOf type. Calculates the types of all possible oneof options for this.
 func (o *OneOfExpression) Type(
-	internalDataModel *schema.ScopeSchema,
+	internalDataModel schema.Scope,
 	functions map[string]schema.Function,
 	workflowContext map[string][]byte,
 ) (schema.Type, error) {

--- a/internal/infer/oneof_expression.go
+++ b/internal/infer/oneof_expression.go
@@ -11,7 +11,7 @@ import (
 type OneOfExpression struct {
 	Discriminator string
 	Options       map[string]any
-	Node          string
+	NodePath      string
 }
 
 func (o *OneOfExpression) String() string {

--- a/internal/infer/oneof_expression.go
+++ b/internal/infer/oneof_expression.go
@@ -1,0 +1,40 @@
+package infer
+
+import (
+	"fmt"
+	"go.flow.arcalot.io/pluginsdk/schema"
+)
+
+// OneOfExpression stores the discriminator, and a key-value pair of all possible oneof values.
+// The keys are the value for the discriminator, and the values are the YAML inputs, which can be
+// inferred within the infer class.
+type OneOfExpression struct {
+	Discriminator string
+	Options       map[string]any
+}
+
+func (o *OneOfExpression) String() string {
+	return fmt.Sprintf("{OneOf Expression; Discriminator: %s; Options: %v}", o.Discriminator, o.Options)
+}
+
+// Type returns the OneOf type. Calculates the types of all possible oneof options for this.
+func (o *OneOfExpression) Type(
+	internalDataModel *schema.ScopeSchema,
+	functions map[string]schema.Function,
+	workflowContext map[string][]byte,
+) (schema.Type, error) {
+	schemas := map[string]schema.Object{}
+	// Gets the type for all options.
+	for optionID, data := range o.Options {
+		inferredType, err := Type(data, internalDataModel, functions, workflowContext)
+		if err != nil {
+			return nil, err
+		}
+		inferredObjectType, isObject := inferredType.(schema.Object)
+		if !isObject {
+			return nil, fmt.Errorf("type of OneOf option is not an object; got %T", inferredType)
+		}
+		schemas[optionID] = inferredObjectType
+	}
+	return schema.NewOneOfStringSchema[any](schemas, o.Discriminator, false), nil
+}

--- a/internal/yaml/parser.go
+++ b/internal/yaml/parser.go
@@ -48,7 +48,8 @@ type Node interface {
 	// Contents returns the contents as further Node items. For maps, this will contain exactly two nodes, while
 	// for sequences this will contain as many nodes as there are items. For strings, this will contain no items.
 	Contents() []Node
-	// MapKey selects a specific map key. If the node is not a map, this function panics.
+	// MapKey selects a specific map key. Returns the node and a bool that represents whether the key was present.
+	// If the node is not a map, this function panics.
 	MapKey(key string) (Node, bool)
 	// MapKeys lists all keys of a map. If the node is not a map, this function panics.
 	MapKeys() []string

--- a/workflow/any.go
+++ b/workflow/any.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"fmt"
+	"go.flow.arcalot.io/engine/internal/infer"
 	"reflect"
 
 	"go.flow.arcalot.io/expressions"
@@ -44,6 +45,9 @@ func (a *anySchemaWithExpressions) Serialize(data any) (any, error) {
 
 func (a *anySchemaWithExpressions) checkAndConvert(data any) (any, error) {
 	if _, ok := data.(expressions.Expression); ok {
+		return data, nil
+	}
+	if _, ok := data.(infer.OneOfExpression); ok {
 		return data, nil
 	}
 	t := reflect.ValueOf(data)

--- a/workflow/any.go
+++ b/workflow/any.go
@@ -44,10 +44,8 @@ func (a *anySchemaWithExpressions) Serialize(data any) (any, error) {
 }
 
 func (a *anySchemaWithExpressions) checkAndConvert(data any) (any, error) {
-	if _, ok := data.(expressions.Expression); ok {
-		return data, nil
-	}
-	if _, ok := data.(infer.OneOfExpression); ok {
+	switch data.(type) {
+	case expressions.Expression, infer.OneOfExpression, *infer.OneOfExpression:
 		return data, nil
 	}
 	t := reflect.ValueOf(data)

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -1035,7 +1035,7 @@ func (e *executor) prepareOneOfExprDependencies(
 	}
 	// Mark the node ID on the OneOfExpression. This mutates the expression, so make sure
 	// this is not operating on a copy of the schema for the data to be retained.
-	expr.Node = oneofDagNode.ID()
+	expr.NodePath = oneofDagNode.ID()
 	for optionID, optionData := range expr.Options {
 		optionDagNode, err := dag.AddNode(
 			oneofDagNode.ID()+"."+optionID, orNodeType)

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -870,7 +870,7 @@ func (e *executor) loadSchema(stepKind step.Provider, stepID string, stepDataMap
 	return runnableStep, nil
 }
 
-func (e *executor) prepareDependencies( //nolint:gocognit,gocyclo
+func (e *executor) prepareDependencies(
 	workflowContext map[string][]byte,
 	stepData any,
 	currentNode dgraph.Node[*DAGItem],

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -985,6 +985,9 @@ func (e *executor) prepareDependencies( //nolint:gocognit,gocyclo
 				return err
 			}
 			err = currentNode.ConnectDependency(oneofDagNode.ID(), dgraph.AndDependency)
+			if err != nil {
+				return err
+			}
 			// Mark the node ID on the OneOfExpression
 			s.Node = oneofDagNode.ID()
 			for optionID, optionData := range s.Options {

--- a/workflow/model.go
+++ b/workflow/model.go
@@ -170,6 +170,9 @@ const (
 	DAGItemKindStepStageOutput DAGItemKind = "stepStageOutput"
 	// DAGItemKindOutput indicates a DAG node for the workflow output.
 	DAGItemKindOutput DAGItemKind = "output"
+	// DagItemKindOrGroup indicates a DAG node used to complete a part of
+	// an input or output that needs dependencies grouped, typically for OR dependencies.
+	DagItemKindOrGroup DAGItemKind = "orGroup"
 )
 
 // DAGItem is the internal structure of the DAG.

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -523,7 +523,7 @@ func (l *loopState) notifySteps() { //nolint:gocognit
 			switch nodeItem.Kind {
 			case DagItemKindOrGroup:
 				if err := node.ResolveNode(dgraph.Resolved); err != nil {
-					l.logger.Errorf("BUG: Error occurred while resolving workflow OR group node (%s)", err.Error())
+					panic(fmt.Errorf("error occurred while resolving workflow OR group node (%s)", err.Error()))
 				}
 				l.notifySteps() // Needs to be called after resolving a node.
 				continue

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -132,7 +132,7 @@ func (e *executableWorkflow) Execute(ctx context.Context, serializedInput any) (
 
 		var stageHandler step.StageChangeHandler = &stageChangeHandler{
 			onStageChange: func(
-				step step.RunningStep,
+				_ step.RunningStep,
 				previousStage *string,
 				previousStageOutputID *string,
 				previousStageOutput *any,
@@ -148,7 +148,7 @@ func (e *executableWorkflow) Execute(ctx context.Context, serializedInput any) (
 				l.onStageComplete(stepID, previousStage, previousStageOutputID, previousStageOutput, wg)
 			},
 			onStepComplete: func(
-				step step.RunningStep,
+				_ step.RunningStep,
 				previousStage string,
 				previousStageOutputID *string,
 				previousStageOutput *any,
@@ -161,7 +161,7 @@ func (e *executableWorkflow) Execute(ctx context.Context, serializedInput any) (
 				}
 				l.onStageComplete(stepID, &previousStage, previousStageOutputID, previousStageOutput, wg)
 			},
-			onStepStageFailure: func(step step.RunningStep, stage string, wg *sync.WaitGroup, err error) {
+			onStepStageFailure: func(_ step.RunningStep, stage string, _ *sync.WaitGroup, err error) {
 				if err == nil {
 					e.logger.Debugf("Step %q stage %q declared that it will not produce an output", stepID, stage)
 				} else {
@@ -698,11 +698,10 @@ func (l *loopState) resolveExpressions(inputData any, dataModel any) (any, error
 		dependencies := oneOfNode.ResolvedDependencies()
 		firstResolvedDependency := ""
 		for dependency, dependencyType := range dependencies {
-			switch dependencyType {
-			case dgraph.OrDependency:
+			if dependencyType == dgraph.OrDependency {
 				firstResolvedDependency = dependency
 				break
-			case dgraph.ObviatedDependency:
+			} else if dependencyType == dgraph.ObviatedDependency {
 				l.logger.Infof("Multiple OR cases triggered; skipping %q", dependency)
 			}
 		}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -691,7 +691,7 @@ func (l *loopState) resolveExpressions(inputData any, dataModel any) (any, error
 
 		// Get the node the OneOf uses to check which Or dependency resolved first (the others will either not be
 		// in the resolved list, or they will be obviated)
-		oneOfNode, err := l.dag.GetNodeByID(expr.Node)
+		oneOfNode, err := l.dag.GetNodeByID(expr.NodePath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get node to resolve oneof expression (%w)", err)
 		}
@@ -708,7 +708,7 @@ func (l *loopState) resolveExpressions(inputData any, dataModel any) (any, error
 		if firstResolvedDependency == "" {
 			return nil, fmt.Errorf("could not find resolved dependency for oneof expression %q", expr.String())
 		}
-		optionID := strings.Replace(firstResolvedDependency, expr.Node+".", "", 1)
+		optionID := strings.Replace(firstResolvedDependency, expr.NodePath+".", "", 1)
 		optionExpr, found := expr.Options[optionID]
 		if !found {
 			return nil, fmt.Errorf("could not find oneof option %q for oneof %q", optionID, expr)

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -482,13 +482,13 @@ input:
   root: RootObject
   objects:
     RootObject:
-      id: RootObject 
+      id: RootObject
       properties: {}
 steps:
   second_wait:
     wait_for: !expr $.steps.first_wait.outputs.success
     kind: foreach
-    items: 
+    items:
     - wait_time_ms: 10
     workflow: subworkflow.yaml
   first_wait:
@@ -608,7 +608,7 @@ input:
   root: RootObject
   objects:
     RootObject:
-      id: RootObject 
+      id: RootObject
       properties: {}
 steps:
   pre_wait:
@@ -621,7 +621,7 @@ steps:
   second_wait:
     wait_for: !expr $.steps.first_wait.starting.started
     kind: foreach
-    items: 
+    items:
     - wait_time_ms: 2
     workflow: subworkflow.yaml
   first_wait:
@@ -778,7 +778,6 @@ steps:
     input:
       wait_time_ms: 0
   wait_2:
-    
     plugin:
       src: "n/a"
       deployment_type: "builtin"
@@ -995,8 +994,8 @@ outputSchema:
   success:
     schema:
       root: RootObjectOut
-      objects: 
-        RootObjectOut: 
+      objects:
+        RootObjectOut:
           id: RootObjectOut
           properties: {}`
 
@@ -1386,7 +1385,7 @@ input:
   root: RootObject
   objects:
     RootObject:
-      id: RootObject 
+      id: RootObject
       properties:
         step_to_run:
           type:
@@ -1814,7 +1813,7 @@ input:
   root: RootObject
   objects:
     RootObject:
-      id: RootObject 
+      id: RootObject
       properties:
         step_to_run:
           type:
@@ -1838,7 +1837,7 @@ steps:
     enabled: !expr $.input.step_to_run == "b"
   subwf_step:
     kind: foreach
-    items: 
+    items:
     - input_1: !oneof
         discriminator: "result"
         one_of:

--- a/workflow/yaml.go
+++ b/workflow/yaml.go
@@ -87,7 +87,6 @@ func buildOneOfExpressions(data yaml.Node, path []string) (any, error) {
 		}
 	}
 
-	// Try just returning
 	discriminator := discriminatorNode.Value()
 	return &infer.OneOfExpression{
 		Discriminator: discriminator,

--- a/workflow/yaml.go
+++ b/workflow/yaml.go
@@ -50,8 +50,13 @@ func (y yamlConverter) FromYAML(data []byte) (*Workflow, error) {
 	return workflow, nil
 }
 
+// YamlOneOfKey is the key to specify the oneof options within a !oneof section.
 const YamlOneOfKey = "one_of"
+
+// YamlDiscriminatorKey is the key to specify the discriminator inside a !oneof section.
 const YamlDiscriminatorKey = "discriminator"
+
+// YamlOneOfTag is the yaml tag that allows the section to be interpreted as a OneOf.
 const YamlOneOfTag = "!oneof"
 
 func buildOneOfExpressions(data yaml.Node, path []string) (any, error) {
@@ -76,7 +81,7 @@ func buildOneOfExpressions(data yaml.Node, path []string) (any, error) {
 	for _, optionNodeKey := range oneOfOptionsNode.MapKeys() {
 		optionNode, _ := oneOfOptionsNode.MapKey(optionNodeKey)
 		var err error
-		options[optionNodeKey], err = yamlBuildExpressions(optionNode, append(path))
+		options[optionNodeKey], err = yamlBuildExpressions(optionNode, append(path, optionNodeKey))
 		if err != nil {
 			return nil, err
 		}

--- a/workflow/yaml.go
+++ b/workflow/yaml.go
@@ -84,7 +84,7 @@ func buildOneOfExpressions(data yaml.Node, path []string) (any, error) {
 
 	// Try just returning
 	discriminator := discriminatorNode.Value()
-	return infer.OneOfExpression{
+	return &infer.OneOfExpression{
 		Discriminator: discriminator,
 		Options:       options,
 	}, nil


### PR DESCRIPTION
## Changes introduced with this PR

This Pull Request adds a way to output a Oneof type. This allows OR logic for outputs and step inputs, allowing you allow multiple cases without creating multiple outputs or steps.

For examples of usage, see `workflow_test.go`

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).