### PR TITLE
Skip tests that require pulling container images

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -148,6 +148,11 @@ output: []`),
 }
 
 func TestE2E(t *testing.T) {
+	if testing.Short() {
+		// This test requires pulling containers; it must not be used when count > 2
+		t.Skip("skipping e2e test in short mode")
+	}
+
 	content := map[string][]byte{
 		"workflow.yaml": []byte(`version: v0.2.0
 input:
@@ -184,6 +189,11 @@ output:
 }
 
 func TestE2EMultipleOutputs(t *testing.T) {
+	if testing.Short() {
+		// This test requires pulling containers; it must not be used when count > 2
+		t.Skip("skipping e2e test in short mode")
+	}
+
 	content := map[string][]byte{
 		"workflow.yaml": []byte(`version: v0.2.0
 input:
@@ -220,6 +230,11 @@ outputs:
 }
 
 func TestE2EWorkflowDefaultInput(t *testing.T) {
+	if testing.Short() {
+		// This test requires pulling containers; it must not be used when count > 2
+		t.Skip("skipping e2e test in short mode")
+	}
+
 	content := map[string][]byte{
 		"workflow.yaml": []byte(`version: v0.2.0
 input:
@@ -262,6 +277,11 @@ outputs:
 // referenced in the main workflow is incorporated into the
 // workflow's execution.
 func Test_CacheSubworkflows(t *testing.T) {
+	if testing.Short() {
+		// This test requires pulling containers; it must not be used when count > 2
+		t.Skip("skipping e2e test in short mode")
+	}
+
 	fileCache, err := loadfile.NewFileCacheUsingContext(
 		"fixtures/test-subworkflow",
 		map[string]string{


### PR DESCRIPTION
## Changes introduced with this PR

I always needed to comment out these tests when running tests 100, 1000, or more times. This makes it as simple as running `go test` with the flag `--short`.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).