### PR TITLE
Added optional expression tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module go.flow.arcalot.io/engine
 
-go 1.21
+go 1.22.0
+
+toolchain go1.22.2
 
 require (
 	go.arcalot.io/assert v1.8.0
-	go.arcalot.io/dgraph v1.6.0
+	go.arcalot.io/dgraph v1.7.0
 	go.arcalot.io/lang v1.1.0
 	go.arcalot.io/log/v2 v2.2.0
 	go.flow.arcalot.io/deployer v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.arcalot.io/assert v1.8.0 h1:hGcHMPncQXwQvjj7MbyOu2gg8VIBB00crUJZpeQOjxs=
 go.arcalot.io/assert v1.8.0/go.mod h1:nNmWPoNUHFyrPkNrD2aASm5yPuAfiWdB/4X7Lw3ykHk=
-go.arcalot.io/dgraph v1.6.0 h1:mJFZ1vdPEg3KtqyhNqYtWVAkxxWBWoJVUFZQ2Z4mbvE=
-go.arcalot.io/dgraph v1.6.0/go.mod h1:+Kxc81utiihMSmC1/ttSPGLDlWPpvgOpNxSFmIDPxFM=
+go.arcalot.io/dgraph v1.7.0 h1:KmVoPoV7jKbc7DgBS7Bmh/gliEXw4S4kyeVpPvyIygs=
+go.arcalot.io/dgraph v1.7.0/go.mod h1:P8mMBGCZbIMVe08iw0afFBMl1QM3aJk+MU//Q2Z5rJc=
 go.arcalot.io/exex v0.2.0 h1:u44pjwPwcH57TF8knhaqVZP/1V/KbnRe//pKzMwDpLw=
 go.arcalot.io/exex v0.2.0/go.mod h1:5zlFr+7vOQNZKYCNOEDdsad+z/dlvXKs2v4kG+v+bQo=
 go.arcalot.io/lang v1.1.0 h1:ugglRKpd3qIMkdghAjKJxsziIgHm8QpxrzZPSXoa08I=
@@ -135,8 +135,6 @@ go.flow.arcalot.io/deployer v0.6.1 h1:Q65VHeRZzdrMJZqTRb26EQZQbK+C3pORETVlpw02xW
 go.flow.arcalot.io/deployer v0.6.1/go.mod h1:Oh+71KYQEof6IS3UGhpMyjQQPRcuomUccn7fwAqrPxE=
 go.flow.arcalot.io/dockerdeployer v0.7.3 h1:CLvSdqfoE8oZADI0wfry46SXR4CQjB6Qh+6Ym70zheQ=
 go.flow.arcalot.io/dockerdeployer v0.7.3/go.mod h1:YWw9+GbYJxEnlahlYCx4UOJe+QNkecf8+EBtSIQD0aE=
-go.flow.arcalot.io/expressions v0.4.3 h1:0BRRghutHp0sctsITHe/A1le0yYiJtKNTxm27T+P6Og=
-go.flow.arcalot.io/expressions v0.4.3/go.mod h1:UORX78N4ep71wOzNXdIo/UY+6SdDD0id0mvuRNEQMeM=
 go.flow.arcalot.io/expressions v0.4.4 h1:bYTC7YDmgDWcsdyY41+IvTJbvsM1rdE3ZBJhB+jNPHQ=
 go.flow.arcalot.io/expressions v0.4.4/go.mod h1:0Y2LgynO1SWA4bqsnKlCxqLME9zOR8tWKg3g+RG+FFQ=
 go.flow.arcalot.io/kubernetesdeployer v0.9.3 h1:XKiqmCqXb6ZLwP5IQTAKS/gJHpq0Ub/yEjCfgAwQF2A=

--- a/internal/infer/optional_expression.go
+++ b/internal/infer/optional_expression.go
@@ -1,0 +1,13 @@
+package infer
+
+import (
+	"go.flow.arcalot.io/expressions"
+)
+
+// OptionalExpression is an expression that can be used in an object as an optional field.
+type OptionalExpression struct {
+	Expr              expressions.Expression
+	WaitForCompletion bool
+	GroupNodePath     string
+	ParentNodePath    string
+}

--- a/workflow/any.go
+++ b/workflow/any.go
@@ -45,7 +45,7 @@ func (a *anySchemaWithExpressions) Serialize(data any) (any, error) {
 
 func (a *anySchemaWithExpressions) checkAndConvert(data any) (any, error) {
 	switch data.(type) {
-	case expressions.Expression, infer.OneOfExpression, *infer.OneOfExpression:
+	case expressions.Expression, infer.OneOfExpression, *infer.OneOfExpression, *infer.OptionalExpression:
 		return data, nil
 	}
 	t := reflect.ValueOf(data)

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -1044,9 +1044,8 @@ func (e *executor) prepareOptionalExprDependencies(
 		dependencyType = dgraph.OptionalDependency
 	}
 
-	// The way that this will work is the current node will depend on the grouped
-	// node to isolate the optional dependencies. The current node will depend on it
-	// with either optional or completion dependencies
+	// Creates a new group node to isolate the optional dependencies.
+	// The current node will depend on the group node with the dependency type set in `dependencyType`.
 	optionalDagNode, err := e.createGroupNode(currentNode, pathInCurrentNode, dag, dependencyType)
 	if err != nil {
 		return err

--- a/workflow/model.go
+++ b/workflow/model.go
@@ -170,9 +170,10 @@ const (
 	DAGItemKindStepStageOutput DAGItemKind = "stepStageOutput"
 	// DAGItemKindOutput indicates a DAG node for the workflow output.
 	DAGItemKindOutput DAGItemKind = "output"
-	// DagItemKindOrGroup indicates a DAG node used to complete a part of
-	// an input or output that needs dependencies grouped, typically for OR dependencies.
-	DagItemKindOrGroup DAGItemKind = "orGroup"
+	// DagItemKindDependencyGroup indicates a DAG node used to complete a part of
+	// an input or output that needs dependencies grouped, typically for OR dependencies
+	// or optional dependencies.
+	DagItemKindDependencyGroup DAGItemKind = "dependencyGroup"
 )
 
 // DAGItem is the internal structure of the DAG.

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -2320,7 +2320,7 @@ func TestSoftOptionalFieldWorkflow(t *testing.T) {
 	})
 	// Test proper failure handling of the required step. The optional value will be available,
 	// but should not be used.
-	outputID, outputData, err = preparedWorkflow.Execute(context.Background(), map[string]any{
+	outputID, _, err = preparedWorkflow.Execute(context.Background(), map[string]any{
 		"wait_1_ms":      0,
 		"wait_2_ms":      0,
 		"wait_1_enabled": false,

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -2266,7 +2266,10 @@ outputs:
 `
 
 func TestSoftOptionalFieldWorkflow(t *testing.T) {
-	// Test the wait time resulting in the soft-optional not being included.
+	// This test case handles the soft optional dependency. It uses timing and step
+	// enablement. Timing is used since there are no order guarantees provided by
+	// `!soft-optional` alone. If this proves to be fragile, consider utilizing
+	// multiple steps that wait for each other in a way that ensures proper ordering.
 	preparedWorkflow := assert.NoErrorR[workflow.ExecutableWorkflow](t)(
 		getTestImplPreparedWorkflow(t, softOptionalFieldWorkflow),
 	)

--- a/workflow/yaml_test.go
+++ b/workflow/yaml_test.go
@@ -195,7 +195,8 @@ func TestBuildWaitOptionalExpr_InvalidExpr(t *testing.T) {
 }
 
 func TestBuildWaitOptionalExpr_InvalidTag(t *testing.T) {
-	// It should never get there outside the unit test.
+	// This code tests an invalid tag used with buildOptionalExpressions that
+	// should not be possible in production code due to other checks.
 	yamlInput := []byte(`!invalid some_expr`)
 	input := assert.NoErrorR[yaml.Node](t)(yaml.New().Parse(yamlInput))
 	_, err := buildOptionalExpression(input, make([]string, 0))


### PR DESCRIPTION
## Changes introduced with this PR

This PR adds two more ways of specifying inferred inputs/outputs:
- `!wait-optional` - Creates a completion dependency that still resolves if the referenced expression fails, but it will wait until either it resolves or it is marked unresolvable. This is the one intended for most use cases. For example, if you don't care if a step succeeds or crashes, `!wait-optional` is the best one for that use case. But if you want the output to only resolve when the step is disabled or succeeds, but not if it crashes, you must use `!ordisabled`.
- `!soft-optional` - Creates an optional dependency that does not effect resolution of the object. There are no order guarantees, so this field is only intended for things that really do not matter strongly for the output.

These expressions may only be used as fields properties within an object. The fields will be marked as optional.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).