### PR TITLE
Use local access for renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>arcalot/.github:renovate-config"
+    "local>arcalot/.github:renovate-config"
   ]
 }


### PR DESCRIPTION
## Changes introduced with this PR

For no obvious reason, unlike all of our other repos, `arcaflow-engine` uses the `github>` prefix to reference the common Renovate configuration.  This PR changes it to `local>` to match our other repos.

This change is prompted by [a discussion in Slack](https://redhat-internal.slack.com/archives/C05C958BQLS/p1727810144969109) exploring the mystery of why, when a new version of  the Podman deployer was released, the `arcalot.github.io` repo was updated promptly  and this repo was not.  The only obvious difference between the repos will be removed when this PR is merged, and, at some point in the future, we'll see if they converge on the same behavior.

(Note that #214 included the deployer update, so there is nothing further for the bot to do on this score.)

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).