### PR TITLE
Attempt to make TestEarlyStepCancellation test more reliable

### DIFF
--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -186,7 +186,7 @@ steps:
 outputs:
   # If not properly cancelled, fail_case will have output.
   fail_case:
-    unattainable: !expr $.steps.last_step.outputs
+    unattainable: !expr $.steps.last_step.outputs.success
   correct_case:
     a: !expr $.steps.end_wait.outputs
 `


### PR DESCRIPTION
## Changes introduced with this PR

[The failure](https://github.com/arcalot/arcaflow-engine/actions/runs/11354047469/job/31580412583#step:8:3592) occurred in 20ms. The step that triggered the wrong output takes 20ms to deploy, and another 20ms of waiting, so it's possible that it's being cancelled, and its cancelled output is racing with the output of the other step. If that's the problem, this should fix it.
I couldn't reproduce the original problem locally, so we'll see if this fixes it. 

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).