### PR TITLE
switch from wait plugin to utilities plugin for wait step

### DIFF
--- a/fixtures/test-subworkflow/depth-1_workflow-1.yaml
+++ b/fixtures/test-subworkflow/depth-1_workflow-1.yaml
@@ -16,7 +16,7 @@ steps:
       deployment_type: image
     step: wait
     input:
-      wait_time_ms: !expr $.input.seconds * 1000
+      wait_time_ms: !expr floatToInt($.input.seconds * 1000.0)
 outputs:
   success:
     a: !expr $.steps.wait_1.outputs

--- a/fixtures/test-subworkflow/depth-1_workflow-1.yaml
+++ b/fixtures/test-subworkflow/depth-1_workflow-1.yaml
@@ -12,11 +12,11 @@ input:
 steps:
   wait_1:
     plugin:
-      src: quay.io/arcalot/arcaflow-plugin-wait:0.2.0
+      src: quay.io/arcalot/arcaflow-plugin-utilities:0.6.1
       deployment_type: image
     step: wait
     input:
-      seconds: !expr $.input.seconds
+      wait_time_ms: !expr $.input.seconds * 1000
 outputs:
   success:
     a: !expr $.steps.wait_1.outputs

--- a/fixtures/test-subworkflow/depth-1_workflow-2.yaml
+++ b/fixtures/test-subworkflow/depth-1_workflow-2.yaml
@@ -16,7 +16,7 @@ steps:
       deployment_type: image
     step: wait
     input:
-      wait_time_ms: !expr $.input.seconds * 1000
+      wait_time_ms: !expr floatToInt($.input.seconds * 1000.0)
   wait_loop:
     kind: foreach
     items:

--- a/fixtures/test-subworkflow/depth-1_workflow-2.yaml
+++ b/fixtures/test-subworkflow/depth-1_workflow-2.yaml
@@ -12,11 +12,11 @@ input:
 steps:
   wait_1:
     plugin:
-      src: quay.io/arcalot/arcaflow-plugin-wait:0.2.0
+      src: quay.io/arcalot/arcaflow-plugin-utilities:0.6.1
       deployment_type: image
     step: wait
     input:
-      seconds: !expr $.input.seconds
+      wait_time_ms: !expr $.input.seconds * 1000
   wait_loop:
     kind: foreach
     items:

--- a/fixtures/test-subworkflow/depth-2_workflow-1.yaml
+++ b/fixtures/test-subworkflow/depth-2_workflow-1.yaml
@@ -16,7 +16,7 @@ steps:
       deployment_type: image
     step: wait
     input:
-      wait_time_ms: !expr $.input.seconds * 1000
+      wait_time_ms: !expr floatToInt($.input.seconds * 1000.0)
   wait_loop:
     kind: foreach
     items:

--- a/fixtures/test-subworkflow/depth-2_workflow-1.yaml
+++ b/fixtures/test-subworkflow/depth-2_workflow-1.yaml
@@ -12,11 +12,11 @@ input:
 steps:
   wait_1:
     plugin:
-      src: quay.io/arcalot/arcaflow-plugin-wait:0.2.0
+      src: quay.io/arcalot/arcaflow-plugin-utilities:0.6.1
       deployment_type: image
     step: wait
     input:
-      seconds: !expr $.input.seconds
+      wait_time_ms: !expr $.input.seconds * 1000
   wait_loop:
     kind: foreach
     items:

--- a/fixtures/test-subworkflow/depth-3_workflow-1.yaml
+++ b/fixtures/test-subworkflow/depth-3_workflow-1.yaml
@@ -16,7 +16,7 @@ steps:
       deployment_type: image
     step: wait
     input:
-      wait_time_ms: !expr $.input.seconds * 1000
+      wait_time_ms: !expr floatToInt($.input.seconds * 1000.0)
 outputs:
   success:
     a: !expr $.steps.wait_1.outputs

--- a/fixtures/test-subworkflow/depth-3_workflow-1.yaml
+++ b/fixtures/test-subworkflow/depth-3_workflow-1.yaml
@@ -12,11 +12,11 @@ input:
 steps:
   wait_1:
     plugin:
-      src: quay.io/arcalot/arcaflow-plugin-wait:0.2.0
+      src: quay.io/arcalot/arcaflow-plugin-utilities:0.6.1
       deployment_type: image
     step: wait
     input:
-      seconds: !expr $.input.seconds
+      wait_time_ms: !expr $.input.seconds * 1000
 outputs:
   success:
     a: !expr $.steps.wait_1.outputs


### PR DESCRIPTION
## Changes introduced with this PR

Changing the plugin used in test conditions to introduce a wait time from the "wait" plugin to the "utilities" plugin. This is part of an effort to eliminate the "wait" plugin as redundant.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).