### PR TITLE
Add support and test multiple wait_for dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	go.flow.arcalot.io/dockerdeployer v0.7.3
 	go.flow.arcalot.io/expressions v0.4.5
 	go.flow.arcalot.io/kubernetesdeployer v0.10.0
-	go.flow.arcalot.io/pluginsdk v0.14.0
+	go.flow.arcalot.io/pluginsdk v0.14.1
 	go.flow.arcalot.io/podmandeployer v0.11.4
 	go.flow.arcalot.io/pythondeployer v0.6.2
 	go.flow.arcalot.io/testdeployer v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ go.flow.arcalot.io/expressions v0.4.5 h1:GHRDHMkYIj2SN/TMc4aRApCewkJjl6moqhXjpdh
 go.flow.arcalot.io/expressions v0.4.5/go.mod h1:0Y2LgynO1SWA4bqsnKlCxqLME9zOR8tWKg3g+RG+FFQ=
 go.flow.arcalot.io/kubernetesdeployer v0.10.0 h1:4Fc6TsmM5pu1E0r9PzNu5AR1Q222B3Uo1Tqka1qqt8k=
 go.flow.arcalot.io/kubernetesdeployer v0.10.0/go.mod h1:OZTuKevUWxEHrlVYDE8+M5bHx1lJO6uwepKq+d3/k1w=
-go.flow.arcalot.io/pluginsdk v0.14.0 h1:GtMaVjhTLIDHfeqnUn2CCJM5BdJF7OVO+/CEcxArDrE=
-go.flow.arcalot.io/pluginsdk v0.14.0/go.mod h1:TOuJdxpyCcLYW+yNUBVe2vs6wFBaJj/z9+44IR1GqCU=
+go.flow.arcalot.io/pluginsdk v0.14.1 h1:S1PKJAXAvfFPmFXoyf7NrjNF+M4SaQzUC/1wWsmoEXU=
+go.flow.arcalot.io/pluginsdk v0.14.1/go.mod h1:TOuJdxpyCcLYW+yNUBVe2vs6wFBaJj/z9+44IR1GqCU=
 go.flow.arcalot.io/podmandeployer v0.11.4 h1:Oj0n1iW3X26dfTM2cgDUswtXNggVAmLpY5BUQqB8zBs=
 go.flow.arcalot.io/podmandeployer v0.11.4/go.mod h1:pc1gGXUAS8YeNkXLaVKApwmurqZ8VgrqZPakH8F/uUk=
 go.flow.arcalot.io/pythondeployer v0.6.2 h1:hIbDpdEhILArf8jMkqJplbxEnYYVcVslbH+IMdtXNy0=


### PR DESCRIPTION
## Changes introduced with this PR

Upgrades the SDK to fix an issue that prevented you from using referenced dependencies (and therefore schemas instead of known values) in maps/objects with ValidateCompatibility.

It also adds a test that uses that feature.


---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).