### PR TITLE
Fix YAML output converting whole-number float64 to int

### DIFF
--- a/cmd/arcaflow/main.go
+++ b/cmd/arcaflow/main.go
@@ -8,6 +8,7 @@ import (
 	"go.arcalot.io/log/v2"
 	"go.flow.arcalot.io/engine"
 	"go.flow.arcalot.io/engine/config"
+	internalyaml "go.flow.arcalot.io/engine/internal/yaml"
 	"go.flow.arcalot.io/engine/loadfile"
 	"go.flow.arcalot.io/engine/workflow"
 	"gopkg.in/yaml.v3"
@@ -216,7 +217,7 @@ func runWorkflow(flow engine.WorkflowEngine, fileCtx loadfile.FileCache, workflo
 		logger.Errorf("Workflow execution failed (%v)", err)
 		return ExitCodeWorkflowFailed
 	}
-	data, err := yaml.Marshal(
+	data, err := internalyaml.Marshal(
 		map[string]any{
 			"output_id":   outputID,
 			"output_data": outputData,

--- a/cmd/run-plugin/run.go
+++ b/cmd/run-plugin/run.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"go.flow.arcalot.io/deployer"
+	internalyaml "go.flow.arcalot.io/engine/internal/yaml"
 	"go.flow.arcalot.io/pluginsdk/plugin"
 	"go.flow.arcalot.io/pluginsdk/schema"
 	podman "go.flow.arcalot.io/podmandeployer"
@@ -162,7 +163,7 @@ func main() {
 		"outputData": result.OutputData,
 		"err":        result.Error,
 	}
-	resultStr, err := yaml.Marshal(output)
+	resultStr, err := internalyaml.Marshal(output)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/yaml/marshal.go
+++ b/internal/yaml/marshal.go
@@ -1,0 +1,153 @@
+package yaml
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Marshal serializes a value to YAML, preserving float64 type fidelity.
+// Unlike yaml.v3's default Marshal, whole-number floats like 99.0 are
+// rendered as "99.0" (not "99"), so consumers parsing the YAML output
+// will correctly interpret them as floats rather than integers.
+func Marshal(v any) ([]byte, error) {
+	node, err := toYAMLNode(v)
+	if err != nil {
+		return nil, err
+	}
+	doc := &yaml.Node{
+		Kind:    yaml.DocumentNode,
+		Content: []*yaml.Node{node},
+	}
+	return yaml.Marshal(doc)
+}
+
+// toYAMLNode recursively converts a Go value into a yaml.Node tree
+// with explicit tags, ensuring type-faithful YAML output.
+func toYAMLNode(v any) (*yaml.Node, error) { //nolint:gocognit,cyclop
+	if v == nil {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!null", Value: "null"}, nil
+	}
+	switch val := v.(type) {
+	case bool:
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!bool",
+			Value: strconv.FormatBool(val),
+		}, nil
+	case string:
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!str",
+			Value: val,
+		}, nil
+	case int:
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!int",
+			Value: strconv.FormatInt(int64(val), 10),
+		}, nil
+	case int64:
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!int",
+			Value: strconv.FormatInt(val, 10),
+		}, nil
+	case uint64:
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!int",
+			Value: strconv.FormatUint(val, 10),
+		}, nil
+	case float32:
+		return floatNode(float64(val)), nil
+	case float64:
+		return floatNode(val), nil
+	case []any:
+		return sliceNode(val)
+	case map[string]any:
+		return stringMapNode(val)
+	case map[any]any:
+		return anyMapNode(val)
+	default:
+		return nil, fmt.Errorf("unsupported type for YAML marshaling: %T", v)
+	}
+}
+
+func floatNode(val float64) *yaml.Node {
+	var s string
+	switch {
+	case math.IsNaN(val):
+		s = ".nan"
+	case math.IsInf(val, 1):
+		s = ".inf"
+	case math.IsInf(val, -1):
+		s = "-.inf"
+	default:
+		s = strconv.FormatFloat(val, 'f', -1, 64)
+		if !strings.Contains(s, ".") {
+			s += ".0"
+		}
+	}
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: s}
+}
+
+func sliceNode(val []any) (*yaml.Node, error) {
+	node := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+	for _, item := range val {
+		child, err := toYAMLNode(item)
+		if err != nil {
+			return nil, err
+		}
+		node.Content = append(node.Content, child)
+	}
+	return node, nil
+}
+
+func stringMapNode(val map[string]any) (*yaml.Node, error) {
+	node := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	keys := make([]string, 0, len(val))
+	for k := range val {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: k}
+		valNode, err := toYAMLNode(val[k])
+		if err != nil {
+			return nil, err
+		}
+		node.Content = append(node.Content, keyNode, valNode)
+	}
+	return node, nil
+}
+
+func anyMapNode(val map[any]any) (*yaml.Node, error) {
+	node := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	type kv struct {
+		sortKey string
+		key     any
+		value   any
+	}
+	pairs := make([]kv, 0, len(val))
+	for k, v := range val {
+		pairs = append(pairs, kv{sortKey: fmt.Sprint(k), key: k, value: v})
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].sortKey < pairs[j].sortKey })
+	for _, p := range pairs {
+		keyNode, err := toYAMLNode(p.key)
+		if err != nil {
+			return nil, err
+		}
+		valNode, err := toYAMLNode(p.value)
+		if err != nil {
+			return nil, err
+		}
+		node.Content = append(node.Content, keyNode, valNode)
+	}
+	return node, nil
+}

--- a/internal/yaml/marshal.go
+++ b/internal/yaml/marshal.go
@@ -28,7 +28,7 @@ func Marshal(v any) ([]byte, error) {
 
 // toYAMLNode recursively converts a Go value into a yaml.Node tree
 // with explicit tags, ensuring type-faithful YAML output.
-func toYAMLNode(v any) (*yaml.Node, error) { //nolint:gocognit,cyclop
+func toYAMLNode(v any) (*yaml.Node, error) { //nolint:cyclop
 	if v == nil {
 		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!null", Value: "null"}, nil
 	}

--- a/internal/yaml/marshal_test.go
+++ b/internal/yaml/marshal_test.go
@@ -1,0 +1,196 @@
+package yaml //nolint:testpackage
+
+import (
+	"math"
+	"testing"
+
+	"go.arcalot.io/assert"
+	goyaml "gopkg.in/yaml.v3"
+)
+
+func TestMarshalFloatWholeNumber(t *testing.T) {
+	out, err := Marshal(float64(99.0))
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), "99.0")
+}
+
+func TestMarshalFloatFractional(t *testing.T) {
+	out, err := Marshal(float64(97.5))
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), "97.5")
+}
+
+func TestMarshalFloatZero(t *testing.T) {
+	out, err := Marshal(float64(0.0))
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), "0.0")
+}
+
+func TestMarshalFloatNegativeWhole(t *testing.T) {
+	out, err := Marshal(float64(-5.0))
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), "-5.0")
+}
+
+func TestMarshalFloat32(t *testing.T) {
+	out, err := Marshal(float32(1.0))
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), "1.0")
+}
+
+func TestMarshalFloatNaN(t *testing.T) {
+	out, err := Marshal(math.NaN())
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), ".nan")
+}
+
+func TestMarshalFloatInf(t *testing.T) {
+	out, err := Marshal(math.Inf(1))
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), ".inf")
+}
+
+func TestMarshalFloatNegInf(t *testing.T) {
+	out, err := Marshal(math.Inf(-1))
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), "-.inf")
+}
+
+func TestMarshalNil(t *testing.T) {
+	out, err := Marshal(nil)
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), "null")
+}
+
+func TestMarshalBool(t *testing.T) {
+	out, err := Marshal(true)
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), "true")
+}
+
+func TestMarshalString(t *testing.T) {
+	out, err := Marshal("hello")
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), "hello")
+}
+
+func TestMarshalInt(t *testing.T) {
+	out, err := Marshal(42)
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), "42")
+}
+
+func TestMarshalInt64(t *testing.T) {
+	out, err := Marshal(int64(-100))
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), "-100")
+}
+
+func TestMarshalUint64(t *testing.T) {
+	out, err := Marshal(uint64(999))
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), "999")
+}
+
+func TestMarshalSlice(t *testing.T) {
+	out, err := Marshal([]any{"a", float64(1.0), nil})
+	assert.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, "- a")
+	assert.Contains(t, s, "- 1.0")
+	assert.Contains(t, s, "- null")
+}
+
+func TestMarshalStringMap(t *testing.T) {
+	out, err := Marshal(map[string]any{
+		"name":  "test",
+		"value": float64(42.0),
+	})
+	assert.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, "name: test")
+	assert.Contains(t, s, "value: 42.0")
+}
+
+func TestMarshalAnyMap(t *testing.T) {
+	out, err := Marshal(map[any]any{
+		"key": float64(10.0),
+	})
+	assert.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, "key: 10.0")
+}
+
+func TestMarshalMapKeysAreSorted(t *testing.T) {
+	out, err := Marshal(map[string]any{
+		"z": 1,
+		"a": 2,
+		"m": 3,
+	})
+	assert.NoError(t, err)
+	s := string(out)
+	aPos := indexOf(s, "a:")
+	mPos := indexOf(s, "m:")
+	zPos := indexOf(s, "z:")
+	assert.Equals(t, aPos < mPos, true)
+	assert.Equals(t, mPos < zPos, true)
+}
+
+func TestMarshalNestedStructure(t *testing.T) {
+	data := map[string]any{
+		"output_data": map[string]any{
+			"percentiles": []any{float64(99.0), float64(95.0), float64(97.5)},
+		},
+	}
+	out, err := Marshal(data)
+	assert.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, "99.0")
+	assert.Contains(t, s, "95.0")
+	assert.Contains(t, s, "97.5")
+}
+
+func TestMarshalRoundTripPreservesFloatTypes(t *testing.T) {
+	data := map[string]any{
+		"values": []any{float64(99.0), float64(95.0), float64(97.5)},
+	}
+	out, err := Marshal(data)
+	assert.NoError(t, err)
+
+	var result map[string]any
+	assert.NoError(t, goyaml.Unmarshal(out, &result))
+
+	values := result["values"].([]any)
+	for i, v := range values {
+		_, ok := v.(float64)
+		if !ok {
+			t.Errorf("values[%d]: expected float64, got %T (value: %v)", i, v, v)
+		}
+	}
+}
+
+func TestMarshalEmptySlice(t *testing.T) {
+	out, err := Marshal([]any{})
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), "[]")
+}
+
+func TestMarshalEmptyMap(t *testing.T) {
+	out, err := Marshal(map[string]any{})
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), "{}")
+}
+
+func TestMarshalUnsupportedType(t *testing.T) {
+	_, err := Marshal(struct{}{})
+	assert.Error(t, err)
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
  Fixes #269                                                                                                                                                                
                                                                                                                                                                            
  ### Summary                                                                                                                                                               
                                                            
  - Add a custom YAML marshaler (`internal/yaml/marshal.go`) that builds a `yaml.Node` tree with explicit `!!float` tags, ensuring whole-number floats like `99.0` retain their decimal notation instead of being rendered as `99`
  - Update the two output call sites (`cmd/arcaflow/main.go`, `cmd/run-plugin/run.go`) to use the new marshaler                                                             
                                                                                                                                                                            
  ### Problem
                                                                                                                                                                            
  Go's `yaml.v3` marshaler renders `float64(99.0)` as `99` in YAML output. Any consumer parsing that YAML interprets `99` as an integer, causing a type change from `float64` to `int`. This means a plugin returning `[99.0, 95.0, 97.5]` produces `[99, 95, 97.5]` in the workflow output.
                                                                                                                                                                            
  ### Root cause                                                                                                                                                            
   
  `yaml.v3` internally uses `strconv.FormatFloat(v, 'G', -1, 64)`, which strips trailing zeros. The engine's internal data pipeline preserves float64 correctly throughout — the type loss occurs only at the final `yaml.Marshal` call.
                                                                                                                                                                            
  ### Fix                                                   

  A new `Marshal` function in `internal/yaml/` constructs a `yaml.Node` tree with explicit type tags rather than relying on the default marshaler's type inference. Float values are formatted with `strconv.FormatFloat(v, 'f', -1, 64)` and given a `.0` suffix when needed. As a bonus, map keys are sorted for deterministic output.
                                                                                                                                                                            
  ### Test plan                                                                                                                                                             
   
  - [x] 23 new unit tests covering all supported types, edge cases (NaN, Inf, empty collections), and a round-trip test verifying `float64(99.0)` survives marshal → unmarshal as `float64`                                    
  - [x] `go build ./...` passes                                                                                                                                             
  - [x] `go vet ./...` clean                                                                                                                                                
  - [x] `go test ./...` passes (excluding pre-existing E2E failures unrelated to this change) 