### PR TITLE
Fix CI for fork PRs: add Go version fallback

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,12 +11,12 @@ jobs:
     name: lint and test
     uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_lint_and_test.yaml@main
     with:
-      go_version: ${{ vars.ARCALOT_GO_VERSION }}
+      go_version: ${{ vars.ARCALOT_GO_VERSION || '1.25' }}
   generate:
     name: go generate
     uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_generate.yaml@main
     with:
-      go_version: ${{ vars.ARCALOT_GO_VERSION }}
+      go_version: ${{ vars.ARCALOT_GO_VERSION || '1.25' }}
   release:
     name: release
     permissions:
@@ -30,7 +30,7 @@ jobs:
       REGISTRY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
     with:
-      go_version: ${{ vars.ARCALOT_GO_VERSION }}
+      go_version: ${{ vars.ARCALOT_GO_VERSION || '1.25' }}
       for_release: ${{ startsWith(github.event.ref, 'refs/tags/') }}
       registry: quay.io
   build_python_wheel:


### PR DESCRIPTION
## Problem

The `vars.ARCALOT_GO_VERSION` repository variable is not available in workflows triggered by pull requests from forks. When it resolves to empty, `actions/setup-go` falls back to the runner's pre-installed Go 1.24, which is too old for the `go 1.25.0` requirement in `go.mod`.

This causes all three CI jobs (go test, golangci-lint, go generate) to fail on any fork-based PR, including #273.

## Fix

Add `|| '1.25'` fallback to all `go_version` inputs in `build.yaml`:

```yaml
go_version: ${{ vars.ARCALOT_GO_VERSION || '1.25' }}
```

When the repo variable is set (pushes to main, internal PRs), it is used as before. When unavailable (fork PRs), Go 1.25 is used as a safe default.